### PR TITLE
Edits to plotting functionality

### DIFF
--- a/redback/analysis.py
+++ b/redback/analysis.py
@@ -46,7 +46,7 @@ def _setup_plotting_result(model, model_kwargs, parameters, transient):
     return model, parameters, res
 
 
-def plot_lightcurve(transient, parameters, model, model_kwargs=None):
+def plot_lightcurve(transient, parameters, model, model_kwargs=None, **kwargs: None):
     """
     Plot a lightcurve for a given model and parameters
 
@@ -58,10 +58,10 @@ def plot_lightcurve(transient, parameters, model, model_kwargs=None):
     """
     model, parameters, res = _setup_plotting_result(model, model_kwargs, parameters, transient)
     return res.plot_lightcurve(model=model, random_models=len(parameters), plot_max_likelihood=False,
-                               save=False, show=False)
+                               save=False, show=False, **kwargs)
 
 
-def plot_multiband_lightcurve(transient, parameters, model, model_kwargs=None):
+def plot_multiband_lightcurve(transient, parameters, model, model_kwargs=None, **kwargs: None):
     """
     Plot a multiband lightcurve for a given model and parameters
 
@@ -73,7 +73,7 @@ def plot_multiband_lightcurve(transient, parameters, model, model_kwargs=None):
     """
     model, parameters, res = _setup_plotting_result(model, model_kwargs, parameters, transient)
     return res.plot_multiband_lightcurve(model=model, random_models=len(parameters), plot_max_likelihood=False,
-                                         save=False, show=False)
+                                         save=False, show=False, **kwargs)
 
 
 def plot_evolution_parameters(result, random_models=100):

--- a/redback/plot_styles/paper.mplstyle
+++ b/redback/plot_styles/paper.mplstyle
@@ -2,13 +2,7 @@ figure.facecolor: white
 figure.frameon: True
 figure.edgecolor: white
 
-axes.labelsize: 18
-axes.titlesize: 18
 axes.grid:False
-xtick.labelsize: 18
-ytick.labelsize: 18
-legend.fontsize: 18
-font.size: 18
 
 grid.linewidth: 0.8
 lines.linewidth: 1.0
@@ -19,9 +13,7 @@ lines.markeredgewidth: 0
 xtick.major.size: 3.0
 ytick.major.size: 3.0
 xtick.minor.size: 1.5
-#xtick.minor.visible: False
 ytick.minor.size: 1.5
-#ytick.minor.visible: False
 
 xtick.major.pad: 2.5
 ytick.major.pad: 2.5
@@ -36,4 +28,3 @@ text.usetex: True
 axes.formatter.use_mathtext: True
 axes.formatter.useoffset: False
 axes.formatter.limits : -3, 3
-#axes.prop_cycle: cycler('color', ['k', 'k', 'k']) + cycler('linestyle', ['-', '--', ':'])

--- a/redback/plotting.py
+++ b/redback/plotting.py
@@ -301,7 +301,7 @@ class IntegratedFluxPlotter(Plotter):
             self.transient.name, xy=self.xy, xycoords=self.xycoords,
             horizontalalignment=self.horizontalalignment, size=self.annotation_size)
 
-        ax.tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
+        ax.tick_params(axis='both', which='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
 
         self._save_and_show(filepath=self._data_plot_filepath, save=save, show=show)
         return ax
@@ -376,7 +376,7 @@ class IntegratedFluxPlotter(Plotter):
             fmt=self.errorbar_fmt, c=self.color, ms=self.ms, elinewidth=self.elinewidth, capsize=self.capsize)
         axes[1].set_yscale("log")
         axes[1].set_ylabel("Residual", fontsize=self.fontsize_axes)
-        axes[1].tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
+        axes[1].tick_params(axis='both', which='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
 
         self._save_and_show(filepath=self._residual_plot_filepath, save=save, show=show)
         return axes
@@ -564,7 +564,7 @@ class MagnitudePlotter(Plotter):
         ax.set_xlabel(self._xlabel, fontsize=self.fontsize_axes)
         ax.set_ylabel(self._ylabel, fontsize=self.fontsize_axes)
 
-        ax.tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
+        ax.tick_params(axis='both', which='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
         ax.legend(ncol=self.legend_cols, loc=self.legend_location, fontsize=self.fontsize_legend)
 
         self._save_and_show(filepath=self._data_plot_filepath, save=save, show=show)
@@ -696,7 +696,7 @@ class MagnitudePlotter(Plotter):
             self._set_x_axis(axes[ii])
             self._set_y_axis_multiband_data(axes[ii], indices)
             axes[ii].legend(ncol=self.legend_cols, loc=self.legend_location, fontsize=self.fontsize_legend)
-            axes[ii].tick_params(axis='both', which='major', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
+            axes[ii].tick_params(axis='both', which='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
             ii += 1
 
         figure.supxlabel(self._xlabel, fontsize=self.fontsize_figure)

--- a/redback/plotting.py
+++ b/redback/plotting.py
@@ -615,11 +615,11 @@ class MagnitudePlotter(Plotter):
                 ys = self.model(times, **self._max_like_params, **self._model_kwargs)
                 if band in self.band_scaling:
                     if self.band_scaling.get("type") == 'x':
-                        axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color_max, alpha=0.65, lw=self.linewidth)
+                        axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color_max, alpha=self.max_likelihood_alpha, lw=self.linewidth)
                     elif self.band_scaling.get("type") == '+':
-                        axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color_max, alpha=0.65, lw=self.linewidth)
+                        axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color_max, alpha=self.max_likelihood_alpha, lw=self.linewidth)
                 else:        
-                    axes.plot(times - self._reference_mjd_date, ys, color=color_max, alpha=0.65, lw=self.linewidth)
+                    axes.plot(times - self._reference_mjd_date, ys, color=color_max, alpha=self.max_likelihood_alpha, lw=self.linewidth)
 
             random_ys_list = [self.model(times, **random_params, **self._model_kwargs)
                               for random_params in self._get_random_parameters()]
@@ -627,11 +627,11 @@ class MagnitudePlotter(Plotter):
                 for ys in random_ys_list:
                     if band in self.band_scaling:
                         if self.band_scaling.get("type") == 'x':
-                            axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color_sample, alpha=0.05, lw=self.linewidth, zorder=-1)
+                            axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color_sample, alpha=self.random_sample_alpha, lw=self.linewidth, zorder=-1)
                         elif self.band_scaling.get("type") == '+':
-                            axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color_sample, alpha=0.05, lw=self.linewidth, zorder=-1)
+                            axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color_sample, alpha=self.random_sample_alpha, lw=self.linewidth, zorder=-1)
                     else:
-                        axes.plot(times - self._reference_mjd_date, ys, color=color_sample, alpha=0.05, lw=self.linewidth, zorder=-1)
+                        axes.plot(times - self._reference_mjd_date, ys, color=color_sample, alpha=self.random_sample_alpha, lw=self.linewidth, zorder=-1)
             elif self.uncertainty_mode == "credible_intervals":
                 if band in self.band_scaling:
                     if self.band_scaling.get("type") == 'x':

--- a/redback/plotting.py
+++ b/redback/plotting.py
@@ -46,7 +46,7 @@ class Plotter(object):
     errorbar_fmt = KwargsAccessorWithDefault("errorbar_fmt", "x")
     model = KwargsAccessorWithDefault("model", None)
     ms = KwargsAccessorWithDefault("ms", 1)
-    x_axis_tick_params_pad = KwargsAccessorWithDefault("x_axis_tick_params_pad", 10)
+    axis_tick_params_pad = KwargsAccessorWithDefault("axis_tick_params_pad", 10)
 
     max_likelihood_alpha = KwargsAccessorWithDefault("max_likelihood_alpha", 0.65)
     random_sample_alpha = KwargsAccessorWithDefault("random_sample_alpha", 0.05)
@@ -66,6 +66,7 @@ class Plotter(object):
     fontsize_axes = KwargsAccessorWithDefault("fontsize_axes", 18)
     fontsize_figure = KwargsAccessorWithDefault("fontsize_figure", 30)
     fontsize_legend = KwargsAccessorWithDefault("fontsize_legend", 18)
+    fontsize_ticks = KwargsAccessorWithDefault("fontsize_ticks", 16)
     hspace = KwargsAccessorWithDefault("hspace", 0.04)
     wspace = KwargsAccessorWithDefault("wspace", 0.15)
 
@@ -97,7 +98,7 @@ class Plotter(object):
         :keyword errorbar_fmt: 'fmt' argument of `ax.errorbar`.
         :keyword model: str or callable, the model to plot.
         :keyword ms: Same as matplotlib markersize.
-        :keyword x_axis_tick_params_pad: `pad` argument in calls to `ax.tick_params` when setting the x axis.
+        :keyword axis_tick_params_pad: `pad` argument in calls to `ax.tick_params` when setting the axes.
         :keyword max_likelihood_alpha: `alpha` argument, i.e. transparency, when plotting the max likelihood curve.
         :keyword random_sample_alpha: `alpha` argument, i.e. transparency, when plotting random sample curves.
         :keyword uncertainty_band_alpha: `alpha` argument, i.e. transparency, when plotting a credible band.
@@ -114,6 +115,7 @@ class Plotter(object):
         :keyword fontsize_legend: Font size of the legend.
         :keyword fontsize_figure: Font size of the figure. Relevant for multiband plots.
                                   Used on `supxlabel` and `supylabel`.
+        :keyword fontsize_ticks: Font size of the axis ticks.
         :keyword hspace: Argument for `subplots_adjust`, sets horizontal spacing between panels.
         :keyword wspace: Argument for `subplots_adjust`, sets horizontal spacing between panels.
         :keyword plot_others: Whether to plot additional bands in the data plot, all in the same colors
@@ -299,7 +301,7 @@ class IntegratedFluxPlotter(Plotter):
             self.transient.name, xy=self.xy, xycoords=self.xycoords,
             horizontalalignment=self.horizontalalignment, size=self.annotation_size)
 
-        ax.tick_params(axis='x', pad=self.x_axis_tick_params_pad)
+        ax.tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
 
         self._save_and_show(filepath=self._data_plot_filepath, save=save, show=show)
         return ax
@@ -318,6 +320,7 @@ class IntegratedFluxPlotter(Plotter):
         :return: The axes with the plot.
         :rtype: matplotlib.axes.Axes
         """
+        
         axes = axes or plt.gca()
 
         axes = self.plot_data(axes=axes, save=False, show=False)
@@ -373,6 +376,8 @@ class IntegratedFluxPlotter(Plotter):
             fmt=self.errorbar_fmt, c=self.color, ms=self.ms, elinewidth=self.elinewidth, capsize=self.capsize)
         axes[1].set_yscale("log")
         axes[1].set_ylabel("Residual", fontsize=self.fontsize_axes)
+        axes[1].tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
+
         self._save_and_show(filepath=self._residual_plot_filepath, save=save, show=show)
         return axes
 
@@ -559,7 +564,7 @@ class MagnitudePlotter(Plotter):
         ax.set_xlabel(self._xlabel, fontsize=self.fontsize_axes)
         ax.set_ylabel(self._ylabel, fontsize=self.fontsize_axes)
 
-        ax.tick_params(axis='x', pad=self.x_axis_tick_params_pad)
+        ax.tick_params(axis='both', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
         ax.legend(ncol=self.legend_cols, loc=self.legend_location, fontsize=self.fontsize_legend)
 
         self._save_and_show(filepath=self._data_plot_filepath, save=save, show=show)
@@ -602,11 +607,11 @@ class MagnitudePlotter(Plotter):
                 ys = self.model(times, **self._max_like_params, **self._model_kwargs)
                 if band in self.band_scaling:
                     if self.band_scaling.get("type") == 'x':
-                        axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color, alpha=0.65, lw=2)
+                        axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color=color, alpha=0.65, lw=self.linewidth)
                     elif self.band_scaling.get("type") == '+':
-                        axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color, alpha=0.65, lw=2)
+                        axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color=color, alpha=0.65, lw=self.linewidth)
                 else:        
-                    axes.plot(times - self._reference_mjd_date, ys, color=color, alpha=0.65, lw=2)
+                    axes.plot(times - self._reference_mjd_date, ys, color=color, alpha=0.65, lw=self.linewidth)
 
             random_ys_list = [self.model(times, **random_params, **self._model_kwargs)
                               for random_params in self._get_random_parameters()]
@@ -614,11 +619,11 @@ class MagnitudePlotter(Plotter):
                 for ys in random_ys_list:
                     if band in self.band_scaling:
                         if self.band_scaling.get("type") == 'x':
-                            axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color='red', alpha=0.05, lw=2, zorder=-1)
+                            axes.plot(times - self._reference_mjd_date, ys * self.band_scaling.get(band), color='red', alpha=0.05, lw=self.linewidth, zorder=-1)
                         elif self.band_scaling.get("type") == '+':
-                            axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color='red', alpha=0.05, lw=2, zorder=-1)
+                            axes.plot(times - self._reference_mjd_date, ys + self.band_scaling.get(band), color='red', alpha=0.05, lw=self.linewidth, zorder=-1)
                     else:
-                        axes.plot(times - self._reference_mjd_date, ys, color='red', alpha=0.05, lw=2, zorder=-1)
+                        axes.plot(times - self._reference_mjd_date, ys, color='red', alpha=0.05, lw=self.linewidth, zorder=-1)
             elif self.uncertainty_mode == "credible_intervals":
                 if band in self.band_scaling:
                     if self.band_scaling.get("type") == 'x':
@@ -663,7 +668,6 @@ class MagnitudePlotter(Plotter):
 
         if figure is None or axes is None:
             figure, axes = plt.subplots(ncols=self.ncols, nrows=self._nrows, sharex='all', figsize=self._figsize)
-
         axes = axes.ravel()
 
         band_label_generator = self.band_label_generator
@@ -692,7 +696,7 @@ class MagnitudePlotter(Plotter):
             self._set_x_axis(axes[ii])
             self._set_y_axis_multiband_data(axes[ii], indices)
             axes[ii].legend(ncol=self.legend_cols, loc=self.legend_location, fontsize=self.fontsize_legend)
-            axes[ii].tick_params(axis='both', which='major', pad=8)
+            axes[ii].tick_params(axis='both', which='major', pad=self.axis_tick_params_pad, labelsize=self.fontsize_ticks)
             ii += 1
 
         figure.supxlabel(self._xlabel, fontsize=self.fontsize_figure)
@@ -725,9 +729,10 @@ class MagnitudePlotter(Plotter):
         return filters
 
     def plot_multiband_lightcurve(
-            self, axes: matplotlib.axes.Axes = None, save: bool = True, show: bool = True) -> matplotlib.axes.Axes:
+        self, figure: matplotlib.figure.Figure = None, axes: matplotlib.axes.Axes = None, save: bool = True, show: bool = True) -> matplotlib.axes.Axes:
         """Plots the Magnitude multiband lightcurve and returns Axes.
 
+        :param figure: Matplotlib figure to plot the data into.
         :param axes: Matplotlib axes to plot the data into. Useful for user specific modifications to the plot.
         :type axes: Union[matplotlib.axes.Axes, None], optional
         :param save: Whether to save the plot. (Default value = True)
@@ -741,9 +746,10 @@ class MagnitudePlotter(Plotter):
         if not self._check_valid_multiband_data_mode():
             return
 
-        axes = axes or plt.gca()
-        axes = self.plot_multiband(axes=axes, save=False, show=False)
+        if figure is None or axes is None:
+            figure, axes = plt.subplots(ncols=self.ncols, nrows=self._nrows, sharex='all', figsize=self._figsize)
 
+        axes = self.plot_multiband(figure=figure, axes=axes, save=False, show=False)
         times = self._get_times(axes)
 
         ii = 0

--- a/redback/transient/transient.py
+++ b/redback/transient/transient.py
@@ -583,8 +583,8 @@ class Transient(object):
             nrows: int = None, figsize: tuple = None, filters: list = None, **kwargs: None) \
             -> matplotlib.axes.Axes:
         """
-        :param figure: Figure can be given if defaults are not satisfying
-        :param axes: Axes can be given if defaults are not satisfying
+        :param figure: Figure can be given if defaults are not satisfying.
+        :param axes: Axes can be given if defaults are not satisfying.
         :param filename: Name of the file to be plotted in.
         :param outdir: The directory in which to save the file in.
         :param save: Whether to save the plot. (Default value = True)
@@ -691,13 +691,15 @@ class Transient(object):
         return plotter.plot_residuals(axes=axes, save=save, show=show)
 
     def plot_multiband_lightcurve(
-            self, model: callable, filename: str = None, outdir: str = None, axes: matplotlib.axes.Axes = None,
+            self, model: callable, filename: str = None, outdir: str = None,
+            figure: matplotlib.figure.Figure = None, axes: matplotlib.axes.Axes = None,
             save: bool = True, show: bool = True, random_models: int = 100, posterior: pd.DataFrame = None,
             model_kwargs: dict = None, **kwargs: object) -> matplotlib.axes.Axes:
         """
         :param model: The model used to plot the lightcurve.
         :param filename: The output filename. Otherwise, use default which starts with the name
                          attribute and ends with *lightcurve.png.
+        :param figure: Figure can be given if defaults are not satisfying.
         :param axes: Axes to plot in if given.
         :param save:Whether to save the plot.
         :param show: Whether to show the plot.
@@ -727,7 +729,7 @@ class Transient(object):
                 posterior=posterior, model_kwargs=model_kwargs, random_models=random_models, **kwargs)
         else:
             return
-        return plotter.plot_multiband_lightcurve(axes=axes, save=save, show=show)
+        return plotter.plot_multiband_lightcurve(figure=figure, axes=axes, save=save, show=show)
 
     _formatted_kwargs_options = redback.plotting.Plotter.keyword_docstring
     plot_data.__doc__ = plot_data.__doc__.replace(


### PR DESCRIPTION
This merge request makes edits to,
- analysis.py
- transient.py
- plotting.py
- paper.mplstyle

with the following changes:
- adds `kwargs` to `plot_lightcurve` function in analysis model to allow custom plotting by the user.
- applies padding to both x and y axes, hence `x_axis_tick_params_pad` was changed to `axis_tick_params_pad`.
- hardcoded variables for `pad`, `lw`, `alpha`, etc. were replaced with user-adjustable parameters.
- adds `fontsize_ticks` parameter to allow user to apply font size changes to ticks on plots.
- adds `which='both'` to `ax.tick_params()`
- fixes functionality of `plot_multiband_lightcurve` and removes the weird "feature, not a bug" figure box (i.e. totally a bug).
- introduced `set_same_color_per_subplot` kwarg, this overrides the `max_likelihood_color` and `random_sample_color` to make the lightcurves and data points the same colour within a subplot.
- removes some parameters from paper.mplstyle which have user-adjustable kwargs in plotting.py