### PR TITLE
Fix in conversion from sqdeg to sqrad

### DIFF
--- a/redback/simulate_transients.py
+++ b/redback/simulate_transients.py
@@ -415,7 +415,7 @@ class SimulateOpticalTransient(object):
         Convert the circular field of view to a radius in radians.
         :return: survey_radius in radians
         """
-        survey_fov_sqrad = self.survey_fov_sqdeg*(np.pi/180.0)
+        survey_fov_sqrad = self.survey_fov_sqdeg*(np.pi/180.0)**2
         survey_radius = np.sqrt(survey_fov_sqrad/np.pi)
         # survey_radius = np.sqrt(self.survey_fov_sqdeg*((np.pi/180.0)**2.0)/np.pi)
         return survey_radius


### PR DESCRIPTION
This pull fixed a typo in [the code that transform survey from square degrees to square radians](https://github.com/nikhil-sarin/redback/blob/e6b17c256b8b44def0520584d31ee4cb6b926029/redback/simulate_transients.py#L418). The line that is commented out still shows the correct equation. It seems this is just a typo that was introduced when the variables were split in [this commit](https://github.com/nikhil-sarin/redback/commit/2e560513aa532b6da331d040120a4b91e78db337).

I have also tested the equation by verifying that the full sky of 41,253 sq deg gives corrrect 4pi sq rad with the updated equation. 