### PR TITLE
Fix setup.py to install dependencies

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,8 +1,1 @@
-nestle
-sherpa
-scikit-learn
-PyQt5
-lalsuite
-kilonova-heating-rate
-redback-surrogates
-kilonovanet
+.[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,1 @@
-numpy<1.26
-setuptools
-pandas
-scipy
-selenium
-sncosmo
-matplotlib
-astropy
-afterglowpy
-extinction
-requests
-lxml
-sphinx-rtd-theme
-sphinx-tabs
-bilby
-regex
+.

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,6 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-requirement_path = f"requirements.txt"
-with open(requirement_path) as f:
-    install_requires = list(f.read().splitlines())
-
-optional_requirement_path = f"optional_requirements.txt"
-with open(optional_requirement_path) as f:
-    optional_install_requires = list(f.read().splitlines())
-
 setup(
     name='redback',
     version='1.0.2',

--- a/setup.py
+++ b/setup.py
@@ -11,23 +11,54 @@ optional_requirement_path = f"optional_requirements.txt"
 with open(optional_requirement_path) as f:
     optional_install_requires = list(f.read().splitlines())
 
-setup(name='redback',
-      version='1.0.2',
-      description='A Bayesian inference pipeline for electromagnetic transients',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url='https://github.com/nikhil-sarin/redback',
-      author='Nikhil Sarin, Moritz Huebner',
-      author_email='nikhil.sarin@su.se',
-      license='GNU General Public License v3 (GPLv3)',
-      packages=['redback', 'redback.get_data', 'redback.transient', 'redback.transient_models'],
-      package_dir={'redback': 'redback', },
-      package_data={'redback': ['priors/*', 'tables/*', 'plot_styles/*']},
-      install_requires=install_requires,
-      extras_require={'all': optional_install_requires},
-      python_requires=">=3.7",
-      classifiers=[
+setup(
+    name='redback',
+    version='1.0.2',
+    description='A Bayesian inference pipeline for electromagnetic transients',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url='https://github.com/nikhil-sarin/redback',
+    author='Nikhil Sarin, Moritz Huebner',
+    author_email='nikhil.sarin@su.se',
+    license='GNU General Public License v3 (GPLv3)',
+    packages=['redback', 'redback.get_data', 'redback.transient', 'redback.transient_models'],
+    package_dir={'redback': 'redback', },
+    package_data={'redback': ['priors/*', 'tables/*', 'plot_styles/*']},
+    install_requires=[
+        "numpy<1.26",
+        "setuptools",
+        "pandas",
+        "scipy",
+        "selenium",
+        "sncosmo",
+        "matplotlib",
+        "astropy",
+        "afterglowpy",
+        "extinction",
+        "requests",
+        "lxml",
+        "sphinx-rtd-theme",
+        "sphinx-tabs",
+        "bilby",
+        "regex",
+    ],
+    extras_require={
+        'all': [
+            "nestle",
+            "sherpa",
+            "scikit-learn",
+            "PyQt5",
+            "lalsuite",
+            "kilonova-heating-rate",
+            "redback-surrogates",
+            "kilonovanet"
+        ]
+    },
+    python_requires=">=3.7",
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",],
-      zip_safe=False)
+        "Operating System :: OS Independent",
+    ],
+    zip_safe=False
+)

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,14 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+requirement_path = f"requirements.txt"
+with open(requirement_path) as f:
+    install_requires = list(f.read().splitlines())
+
+optional_requirement_path = f"optional_requirements.txt"
+with open(optional_requirement_path) as f:
+    optional_install_requires = list(f.read().splitlines())
+
 setup(name='redback',
       version='1.0.2',
       description='A Bayesian inference pipeline for electromagnetic transients',
@@ -15,6 +23,8 @@ setup(name='redback',
       packages=['redback', 'redback.get_data', 'redback.transient', 'redback.transient_models'],
       package_dir={'redback': 'redback', },
       package_data={'redback': ['priors/*', 'tables/*', 'plot_styles/*']},
+      install_requires=install_requires,
+      extras_require={'all': optional_install_requires},
       python_requires=">=3.7",
       classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR fixes https://github.com/nikhil-sarin/redback/issues/224. It moves the master list dependencies and optional dependencies to setup.py, while maintaining backwards compatibility.

Now, the standard dependencies are listed under `install_requires` in `setup.py` , running `pip install .` (and `pip install redback` once pushed to pypi) will automatically install these dependencies. The `requirements.txt` file now points to the dependencies listed in `setup.py`, so `pip install -r requirements.txt` still works too!

In addition, the optional dependencies are listed correctly under `extras_require`. So running `pip install ".[all]"` (and `pip install redback[all]` once pushed to pypi) will install both regular and optional dependencies. The `optional_requirements.txt` file now points to these optional dependencies listed in `setup.py`, so `pip install -r optional_requirements.txt` still works too!