### PR TITLE
Update afterglow_models.py

### DIFF
--- a/redback/transient_models/afterglow_models.py
+++ b/redback/transient_models/afterglow_models.py
@@ -285,16 +285,16 @@ class RedbackAfterglows():
         te = np.arcsin(cs / (self.cc * (G2 - 1.) ** 0.5))  # equivalent form for angle due to spreading
         # prepare ex and OmG in this function
         if self.is_expansion:
-            ex = te  # expansion
+            ex = te / (G2 * latstep) # expansion
             fac = 0.5 * latstep
-            OmG = rotstep * (np.cos(thi - fac) - np.cos(ex + thi + fac))  # equivalent form for linear spacing
+            OmG = rotstep * (np.cos(thi - fac) - np.cos(ex/self.res + thi + fac))  # equivalent form for linear spacing
         else:
             te = np.ones(te.size)  # no expansion
             fac = 0.5 * latstep
             OmG = rotstep * (np.cos(thi - fac) - np.cos(thi + fac))  # equivalent form for linear spacing
         # prepare R
         size = G.size
-        exponent = ((1 - np.cos(te[0])) / (1 - np.cos(te[:size]))) ** 0.5
+        exponent = ((1 - np.cos(te[0])) / (1 - np.cos(te[:size]))) ** (1/3)
         R = ((3. - k) * Ne[:size] / (self.fourpi * n)) ** (1. / (3. - k))
         R[1:] = np.diff(R) * exponent[1:size] ** (1. / (3. - k))
         R = np.cumsum(R)


### PR DESCRIPTION
Updated the expansion description within the redback_afterglow model from exponential, to quasi-(Granot-Piran 2012). The original sound-speed approximation was an absolute upper-limit and overestimates spreading compared to hydro-simulations.