### PR TITLE
Switch to the new Fink API URL

### DIFF
--- a/redback/get_data/fink.py
+++ b/redback/get_data/fink.py
@@ -45,7 +45,7 @@ class FinkDataGetter(DataGetter):
         :return: The fink raw data url.
         :rtype: str
         """
-        return "https://fink-portal.org/api/v1/objects"
+        return "https://api.fink-portal.org/api/v1/objects"
 
     @property
     def objectId(self) -> str:

--- a/test/get_data_test.py
+++ b/test/get_data_test.py
@@ -671,7 +671,7 @@ class TestFinkDataGetter(unittest.TestCase):
         self.assertEqual(expected_processed_file_path, self.getter.processed_file_path)
 
     def test_url(self):
-        expected = "https://fink-portal.org/api/v1/objects"
+        expected = "https://api.fink-portal.org/api/v1/objects"
         self.assertEqual(expected, self.getter.url)
 
     def test_object_id(self):


### PR DESCRIPTION
Hello,

As part of the transition to a new system for Rubin, the URL to access the Fink API has changed:
- old: https://fink-portal.org/api/v1/<endpoint\>
- new: https://api.fink-portal.org/api/v1/<endpoint\>

In this transition period, in case of trouble do not hesitate to check https://fink-broker.readthedocs.io/en/latest/migration