### PR TITLE
Vectorized magnetar

### DIFF
--- a/redback/sed.py
+++ b/redback/sed.py
@@ -239,7 +239,12 @@ class _SED(object):
         # add distance units
         flux_density /= (4 * np.pi * self.luminosity_distance ** 2)
         # get rid of Angstrom and normalise to frequency
-        if flux_density.ndim == 2:
+        try:
+            self.time
+            flag = True
+        except NameError:
+            flag = False
+        if (flux_density.ndim == 2) and flag:
             flux_density *= nu_to_lambda(np.tile(self.frequency.T, (len(self.time), 1)).T)
             flux_density /= np.tile(self.frequency.T, (len(self.time), 1)).T
         else:

--- a/redback/sed.py
+++ b/redback/sed.py
@@ -242,7 +242,7 @@ class _SED(object):
         try:
             self.time
             flag = True
-        except NameError:
+        except AttributeError:
             flag = False
         if (flux_density.ndim == 2) and flag:
             flux_density *= nu_to_lambda(np.tile(self.frequency.T, (len(self.time), 1)).T)

--- a/redback/sed.py
+++ b/redback/sed.py
@@ -239,17 +239,8 @@ class _SED(object):
         # add distance units
         flux_density /= (4 * np.pi * self.luminosity_distance ** 2)
         # get rid of Angstrom and normalise to frequency
-        try:
-            self.time
-            flag = True
-        except AttributeError:
-            flag = False
-        if (flux_density.ndim == 2) and flag:
-            flux_density *= nu_to_lambda(np.tile(self.frequency.T, (len(self.time), 1)).T)
-            flux_density /= np.tile(self.frequency.T, (len(self.time), 1)).T
-        else:
-            flux_density *= nu_to_lambda(self.frequency)
-            flux_density /= self.frequency
+        flux_density *= nu_to_lambda(self.frequency)
+        flux_density /= self.frequency
 
         # add units
         flux_density = flux_density << self.UNITS

--- a/redback/transient_models/supernova_models.py
+++ b/redback/transient_models/supernova_models.py
@@ -833,13 +833,12 @@ def slsn(time, redshift, p0, bp, mass_ns, theta_pb,**kwargs):
         lbol = slsn_bolometric(time=time, p0=p0, bp=bp, mass_ns=mass_ns, theta_pb=theta_pb, **kwargs)
         photo = kwargs['photosphere'](time=time, luminosity=lbol, **kwargs)
         full_sed = np.zeros((len(time), len(frequency)))
-        for ii in range(len(frequency)):
-            ss = kwargs['sed'](time=time, temperature=photo.photosphere_temperature,
-                               r_photosphere=photo.r_photosphere, frequency=frequency[ii],
-                               luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=lbol)
-            full_sed[:, ii] = ss.flux_density.to(uu.mJy).value            
+        ss = kwargs['sed'](time=time_temp/day_to_s, temperature=photo.photosphere_temperature,
+                        r_photosphere=photo.r_photosphere, frequency=frequency[:, None],
+                        luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=output.bolometric_luminosity)
+        full_sed = ss.flux_density.to(uu.mJy).value.T    
         spectra = (full_sed * uu.mJy).to(uu.erg / uu.cm ** 2 / uu.s / uu.Angstrom,
-                                         equivalencies=uu.spectral_density(wav=lambda_observer_frame * uu.Angstrom))
+                                    equivalencies=uu.spectral_density(wav=lambda_observer_frame * uu.Angstrom))
         if kwargs['output_format'] == 'spectra':
             return namedtuple('output', ['time', 'lambdas', 'spectra'])(time=time_observer_frame,
                                                                           lambdas=lambda_observer_frame,

--- a/redback/transient_models/supernova_models.py
+++ b/redback/transient_models/supernova_models.py
@@ -833,9 +833,9 @@ def slsn(time, redshift, p0, bp, mass_ns, theta_pb,**kwargs):
         lbol = slsn_bolometric(time=time, p0=p0, bp=bp, mass_ns=mass_ns, theta_pb=theta_pb, **kwargs)
         photo = kwargs['photosphere'](time=time, luminosity=lbol, **kwargs)
         full_sed = np.zeros((len(time), len(frequency)))
-        ss = kwargs['sed'](time=time_temp/day_to_s, temperature=photo.photosphere_temperature,
+        ss = kwargs['sed'](time=time, temperature=photo.photosphere_temperature,
                         r_photosphere=photo.r_photosphere, frequency=frequency[:, None],
-                        luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=output.bolometric_luminosity)
+                        luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=lbol)
         full_sed = ss.flux_density.to(uu.mJy).value.T    
         spectra = (full_sed * uu.mJy).to(uu.erg / uu.cm ** 2 / uu.s / uu.Angstrom,
                                     equivalencies=uu.spectral_density(wav=lambda_observer_frame * uu.Angstrom))

--- a/redback/transient_models/supernova_models.py
+++ b/redback/transient_models/supernova_models.py
@@ -1796,11 +1796,10 @@ def general_magnetar_driven_supernova(time, redshift, mej, E_sn, kappa, l0, tau_
             return dynamics_output
         else: 
             full_sed = np.zeros((len(time), len(frequency)))
-            for ii in range(len(frequency)):
-                ss = kwargs['sed'](time=time_temp/day_to_s, temperature=photo.photosphere_temperature,
-                               r_photosphere=photo.r_photosphere, frequency=frequency[ii],
-                               luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=output.bolometric_luminosity)
-                full_sed[:, ii] = ss.flux_density.to(uu.mJy).value
+            ss = kwargs['sed'](time=time_temp/day_to_s, temperature=photo.photosphere_temperature,
+                            r_photosphere=photo.r_photosphere, frequency=frequency[:, None],
+                            luminosity_distance=dl, cutoff_wavelength=cutoff_wavelength, luminosity=output.bolometric_luminosity)
+            full_sed = ss.flux_density.to(uu.mJy).value.T    
             spectra = (full_sed * uu.mJy).to(uu.erg / uu.cm ** 2 / uu.s / uu.Angstrom,
                                         equivalencies=uu.spectral_density(wav=lambda_observer_frame * uu.Angstrom))
             if kwargs['output_format'] == 'spectra':


### PR DESCRIPTION
Changed cutoff blackbody in sed.py to take inputs of different length for time and frequency, letting us discard for loops in the "slsn" and "general_magnetar_driven_supernova" models and speed them up.