### PR TITLE
Add a wrapper for optional jit compilation

### DIFF
--- a/redback/wrappers.py
+++ b/redback/wrappers.py
@@ -1,0 +1,39 @@
+import warnings
+
+
+def cond_jit(func=None, **kwargs):
+    """A conditional function wrapper for number jit functions.
+
+    Parameters
+    ----------
+    func : callable, optional
+        The function to wrap. This is automatically passed when
+        the decorator has explicit arguments (e.g. no () afterward).
+    **kwargs : keyword arguments
+        Additional arguments to pass to the JIT compiler.
+
+    Returns
+    -------
+    function
+        The wrapped function or method.
+    """
+    try:
+        # Try to use numba's jit function wrapper directly.
+        from numba import jit
+
+        decorator = jit(**kwargs)
+    except ImportError:
+        warnings.warn("Numba is not installed. Using the non-compiled function.")
+
+        # If numba is not available, fall back to a no-op decorator.
+        def no_op_decorator(func):
+            return func
+
+        decorator = no_op_decorator
+
+    # We check if the user passed a function to wrap. This is needed
+    # because func may be None if the decorator is used without parentheses
+    # otherwise the decorator will be applied to the function itself.
+    if func is not None:
+        return decorator(func)
+    return decorator

--- a/test/wrapper_test.py
+++ b/test/wrapper_test.py
@@ -1,0 +1,49 @@
+import unittest
+import warnings
+
+from redback.wrappers import cond_jit
+
+
+class ConditionalJITTest(unittest.TestCase):
+
+    def test_wrapper_no_args_implicit(self):
+        """Check that we can define a conditional JIT wrapper (with
+        no arguments) and still evaluate the function."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # Leaving out the parentheses will pass the function itself
+            # as the first argument to the decorator.
+            @cond_jit
+            def _my_func(x):
+                return x + 1
+
+        self.assertEqual(_my_func(1), 2)
+
+    def test_wrapper_no_args_explicit(self):
+        """Check that we can define a conditional JIT wrapper (with
+        no arguments) and still evaluate the function."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # Including empty parentheses will pass NO arguments
+            # (including the function itself).
+            @cond_jit()
+            def _my_func(x):
+                return x + 1
+
+        self.assertEqual(_my_func(1), 2)
+
+    def test_wrapper_args(self):
+        """Check that we can define a conditional JIT wrapper (with
+        arguments) and still evaluate the function."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # Only the included arguments will be passed
+            # (not the function itself).
+            @cond_jit(nopython=True, fastmath=True, cache=True)
+            def _my_func(x):
+                return x + 1
+
+        self.assertEqual(_my_func(1), 2)


### PR DESCRIPTION
Using @cond_jit will use numba jit compilation if numba is installed and otherwise keep the function as-is.