### PR TITLE
Add automated PyPI release workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,100 @@
+# This workflow will build and publish the package to PyPI when a release tag is pushed
+# For more information see: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags like v1.12.1, v2.0.0, etc.
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build setuptools wheel twine
+
+    - name: Build distribution packages
+      run: python -m build
+
+    - name: Verify distribution
+      run: twine check dist/*
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/redback
+
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # If using API token instead of trusted publishing, uncomment:
+        # password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true
+
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-to-pypi]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        gh release create '${{ github.ref_name }}' \
+          --repo '${{ github.repository }}' \
+          --notes "Release ${{ github.ref_name }}"
+
+    - name: Upload distribution packages to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        gh release upload '${{ github.ref_name }}' dist/** \
+          --repo '${{ github.repository }}'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,96 @@
+# Release Process
+
+This document describes the automated PyPI release process for redback.
+
+## Overview
+
+The project uses GitHub Actions to automatically publish releases to PyPI when version tags are pushed.
+
+## Setup
+
+### Option 1: Trusted Publishing (Recommended)
+
+Trusted publishing is the modern, secure way to publish to PyPI without using API tokens.
+
+1. Go to https://pypi.org/manage/account/publishing/
+2. Add a new pending publisher with:
+   - **PyPI Project Name**: `redback`
+   - **Owner**: `nikhil-sarin`
+   - **Repository name**: `redback`
+   - **Workflow name**: `pypi-publish.yml`
+   - **Environment name**: `pypi`
+
+The workflow is already configured to use trusted publishing by default.
+
+### Option 2: API Token
+
+If you prefer to use an API token:
+
+1. Generate a PyPI API token at https://pypi.org/manage/account/token/
+2. Add the token as a repository secret named `PYPI_API_TOKEN`
+3. Uncomment the `password` line in `.github/workflows/pypi-publish.yml`:
+   ```yaml
+   password: ${{ secrets.PYPI_API_TOKEN }}
+   ```
+
+## How to Release
+
+### 1. Update Version
+
+Update the version number in `setup.py`:
+
+```python
+setup(
+    name='redback',
+    version='1.12.2',  # Update this
+    ...
+)
+```
+
+### 2. Commit Changes
+
+```bash
+git add setup.py
+git commit -m "Bump version to 1.12.2"
+git push
+```
+
+### 3. Create and Push Tag
+
+```bash
+git tag v1.12.2
+git push origin v1.12.2
+```
+
+### 4. Automated Process
+
+Once the tag is pushed, the workflow automatically:
+1. Builds the distribution packages (wheel and source distribution)
+2. Verifies the packages
+3. Publishes to PyPI
+4. Creates a GitHub release with the distribution files attached
+
+## Manual Trigger
+
+The workflow can also be triggered manually from the Actions tab on GitHub.
+
+## Monitoring
+
+You can monitor the release process in the "Actions" tab of the repository. The workflow will show:
+- Build status
+- PyPI publication status
+- GitHub release creation status
+
+## Troubleshooting
+
+### Publication Fails
+
+- **Trusted Publishing**: Ensure the publisher is configured correctly on PyPI
+- **API Token**: Verify the `PYPI_API_TOKEN` secret is set correctly
+- **Version Conflict**: Ensure the version doesn't already exist on PyPI
+
+### Build Fails
+
+- Check that all dependencies are properly specified in `setup.py`
+- Verify the package structure is correct
+- Review the workflow logs for specific error messages


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the release process to PyPI:

- Workflow triggers on version tags (e.g., v1.12.1)
- Supports both trusted publishing (recommended) and API token authentication
- Automatically builds distribution packages (wheel and source)
- Publishes to PyPI after successful build
- Creates GitHub releases with distribution files attached
- Can be manually triggered via workflow_dispatch

Also includes RELEASE.md documentation with:
- Setup instructions for both trusted publishing and API tokens
- Step-by-step release process
- Troubleshooting guide

This automation streamlines the release process and reduces manual errors.