### PR TITLE
Automatically link __version__ to setup.py

### DIFF
--- a/redback/__init__.py
+++ b/redback/__init__.py
@@ -5,5 +5,22 @@ from redback.transient import afterglow, kilonova, prompt, supernova, tde
 from redback.sampler import fit_model
 from redback.utils import setup_logger
 
-__version__ = "1.12.1"
+# Read version from setup.py to maintain single source of truth
+import re
+import os
+
+def _get_version():
+    """Extract version from setup.py"""
+    setup_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setup.py')
+    try:
+        with open(setup_path, 'r') as f:
+            content = f.read()
+            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", content)
+            if match:
+                return match.group(1)
+    except (FileNotFoundError, IOError):
+        pass
+    return "unknown"
+
+__version__ = _get_version()
 setup_logger(log_level='info')


### PR DESCRIPTION
## Automatically link __version__ to setup.py

This PR implements automatic version linking between `redback/__init__.py` and `setup.py` to maintain a single source of truth for the package version.

### Changes
- Modified `redback/__init__.py` to dynamically read the version from `setup.py` using regex pattern matching
- Added `_get_version()` helper function that extracts the version string from setup.py
- Falls back to "unknown" if setup.py cannot be read

### Benefits
- **Single source of truth**: Version only needs to be updated in `setup.py`
- **Eliminates version drift**: No more mismatches between `__init__.py` and `setup.py` versions
- **Simplifies releases**: Release process only needs to update one file
- **Backward compatible**: The `__version__` attribute still works exactly as before

### Testing
Tested that `import redback; print(redback.__version__)` correctly returns the version from setup.py (currently 1.13.0).

### Implementation Details
The function:
1. Locates setup.py relative to the package directory
2. Reads the file and searches for the version pattern using regex
3. Returns the matched version or "unknown" if not found
4. Handles FileNotFoundError gracefully

This approach is simple, has no external dependencies, and works reliably for the current project structure.