### PR TITLE
Release version 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # All notable changes will be documented in this file
 
+## [1.13.1] 2026-01-27
+Version 1.13.1 release of redback
+
+## Changed
+* Automatically link __version__ to setup.py for single source of truth
+
+## What's Changed
+* Automatically link __version__ to setup.py by @nikhil-sarin in https://github.com/nikhil-sarin/redback/pull/336
+
+**Full Changelog**: https://github.com/nikhil-sarin/redback/compare/v1.13.0...v1.13.1
+
 ## [1.13.0] 2026-01-27
 Version 1.13.0 release of redback
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='redback',
-    version='1.13.0',
+    version='1.13.1',
     description='A Bayesian inference and modelling pipeline for electromagnetic transients',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Release v1.13.1

This PR prepares version 1.13.1 for release.

### Changes
- Updated version in setup.py to 1.13.1
- Added changelog entry

### Changelog Summary
This is a patch release with one internal improvement:
- Automatically link __version__ to setup.py for single source of truth
- This eliminates the need to manually update version in two places during releases
- No user-facing changes

Once merged, the GitHub Actions workflow will automatically publish to PyPI.

### Checklist
- [x] Version updated in setup.py
- [x] Changelog updated with changes since v1.13.0
- [x] Git tag v1.13.1 created and pushed