### PR TITLE
Release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # All notable changes will be documented in this file
 
+## [1.16.0] 2026-05-11
+Version 1.16.0 release of redback
+
+## Added and changed
+* Added multimessenger analysis framework: `MultiMessengerTransient`, `MultiMessengerLikelihood`, `create_joint_prior`, and `MultiMessengerResult` classes (#310)
+* Overhauled non-detection interface to be more automatic and robust (#361, #362)
+* Hardened multimessenger non-detection support with scalarized constraint/sample handling
+* Added Fink API smoke tests (live and mocked empty-response)
+* Improved multimessenger result coverage and example
+* CSM interaction: adaptive grid for diffusion evaluation, significant speed-up
+* CSM nickel: nickel now diffuses through CSM ejecta for dense CSM regime
+* CSM photosphere consistency check added
+* Filter table cleanup: removed duplicate Gaia/G and DES entries, grouped rows more coherently
+* Extinction model lists now auto-generated
+* Smarter corner plots
+* Preserved time errors for upper-limit fallback
+* Updated CSM nickel citations
+
+**Full Changelog**: https://github.com/nikhil-sarin/redback/compare/v1.15.3...v1.16.0
+
 ## [1.15.3] 2026-04-10
 Version 1.15.3 release of redback
 

--- a/redback/get_data/fink.py
+++ b/redback/get_data/fink.py
@@ -75,12 +75,14 @@ class FinkDataGetter(DataGetter):
             response = requests.post(url=self.url,
                 json={'objectId': self.objectId, 'output-format': 'csv', 'withupperlim': 'True'},
                 timeout=30)
+            response.raise_for_status()
             data = pd.read_csv(io.BytesIO(response.content))
         elif self.source == 'lsst':
             logger.info(f"Fetching LSST data for {self.transient} from {self.url}")
             response = requests.post(url=self.url,
                 json={'diaObjectId': self.objectId, 'output-format': 'csv', 'withupperlim': 'True'},
                 timeout=30)
+            response.raise_for_status()
             logger.info(f"Got response: status={response.status_code}, content_length={len(response.content)}")
             data = pd.read_csv(io.BytesIO(response.content))
             logger.info(f"Parsed DataFrame: shape={data.shape}, len={len(data)}")

--- a/redback/multimessenger.py
+++ b/redback/multimessenger.py
@@ -425,6 +425,8 @@ class MultiMessengerTransient:
                 detection_mask = detections
                 likelihood_class = GaussianLikelihood
                 x, y, y_err = x[detection_mask], y[detection_mask], y_err[detection_mask]
+                if x_err is not None:
+                    x_err = x_err[detection_mask]
             else:
                 logger.info(
                     f"Building GaussianLikelihoodWithUpperLimits for {messenger} with "
@@ -637,7 +639,7 @@ class MultiMessengerTransient:
             label=label,
             resume=resume,
             use_ratio=False,
-            maxmcmc=10 * walks,
+            maxmcmc=kwargs.pop('maxmcmc', 10 * walks),
             result_class=MultiMessengerResult,
             meta_data=meta_data,
             save=save_format,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='redback',
-    version='1.15.3',
+    version='1.16.0',
     description='A Bayesian inference and modelling pipeline for electromagnetic transients',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Release v1.16.0

### Changes

**Added**
- Multimessenger analysis framework: `MultiMessengerTransient`, `MultiMessengerLikelihood`, `create_joint_prior`, and `MultiMessengerResult` classes (#310)
- Fink API smoke tests (live and mocked empty-response)

**Changed / Improved**
- Non-detection interface overhauled to be more automatic and robust (#361, #362)
- Hardened multimessenger non-detection support with scalarized constraint/sample handling
- CSM interaction: adaptive grid for diffusion evaluation, significant speed-up
- CSM nickel: nickel now diffuses through CSM ejecta for dense CSM regime; updated citations
- CSM photosphere consistency check added
- Filter table cleanup: removed duplicate Gaia/G and DES entries
- Extinction model lists now auto-generated
- Smarter corner plots; preserved time errors for upper-limit fallback

### Checklist
- [x] Version bumped in `setup.py` (1.15.3 → 1.16.0)
- [x] CHANGELOG updated
- [x] Tests passing

### After merge
Once this PR is merged, run:
```
git checkout master && git pull origin master
git tag -a v1.16.0 -m "Release v1.16.0"
git push origin v1.16.0
```
CI will then build, publish to PyPI, and create the GitHub release automatically.