### PR TITLE
Only require `sphinx`, etc. for doc builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 __pycache__/
 
 # Setuptools distribution folder.
-/dist/
+dist/
+build/
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,16 @@ setup(
         'redback.transient_models.afterglow_models',
     ],
     package_dir={'redback': 'redback', },
-    package_data={'redback': ['priors/*', 'priors/non_default_priors/*', 'tables/*', 'tables/xsect/*',
-                              'tables/guillochon_tde_data/*/*', 'plot_styles/*']},
+    package_data={
+        'redback': [
+            'priors/*',
+            'priors/non_default_priors/*',
+            'tables/*',
+            'tables/xsect/*',
+            'tables/guillochon_tde_data/*/*',
+            'plot_styles/*'
+            ]
+        },
     install_requires=[
         "numpy",
         "numba",

--- a/setup.py
+++ b/setup.py
@@ -35,14 +35,17 @@ setup(
         "extinction",
         "requests",
         "lxml",
-        "sphinx-rtd-theme",
-        "sphinx-tabs",
         "bilby",
         "regex",
         "sncosmo",
         "afterglowpy",
     ],
     extras_require={
+        'docs': [
+            "sphinx",
+            "sphinx-rtd-theme",
+            "sphinx-tabs",
+        ],
         'all': [
             "nestle",
             "sherpa",


### PR DESCRIPTION
Most regular users/installations don't need the whole sphinx stack just to use the software. This PR moves those dependencies to an optional "docs" extra. They can still be pulled in if desired with `pip install redback[docs]`. This makes normal installation much more lightweight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file exclusions to omit generated build and distribution directories.
  * Reorganized package configuration for improved readability.
  * Separated documentation-related packages from core runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->