### PR TITLE
Fix `t0_*_extinction` models when `time` contains epochs before `t0` and `bands`/`frequency` are vector(s)

### DIFF
--- a/redback/transient_models/phase_models.py
+++ b/redback/transient_models/phase_models.py
@@ -74,9 +74,17 @@ def _t0_with_extinction(time, t0, av_host, model_type='supernova', **kwargs):
     t0 = Time(t0, format='mjd')
     time = Time(np.asarray(time, dtype=float), format='mjd')
     time = (time - t0).to(uu.day).value
-    transient_time = time[time >= 0.0]
-    bad_time = time[time < 0.0]
-    output_real = function(transient_time, av_host=av_host, **kwargs)
+    valid_time = time >= 0.0
+    transient_time = time[valid_time]
+    bad_time = time[~valid_time]
+    temp_kwargs = kwargs.copy()
+    if 'frequency' in temp_kwargs:
+        if isinstance(temp_kwargs['frequency'], np.ndarray):
+            temp_kwargs['frequency'] = kwargs['frequency'][valid_time]
+    if 'bands' in temp_kwargs:
+        if isinstance(temp_kwargs['bands'], np.ndarray):
+            temp_kwargs['bands'] = kwargs['bands'][valid_time]
+    output_real = function(transient_time, av_host=av_host, **temp_kwargs)
     if kwargs['output_format'] == 'magnitude':
         output_fake = np.zeros(len(bad_time)) + 5000
     else:

--- a/redback/transient_models/phase_models.py
+++ b/redback/transient_models/phase_models.py
@@ -18,6 +18,22 @@ extinction_model_functions = {'supernova':extinction_models.extinction_with_supe
                               'shock_powered':extinction_models.extinction_with_shock_powered_base_model,
                               'stellar_interaction':extinction_models.extinction_with_stellar_interaction_base_model}
 
+def _mask_per_epoch_kwargs(kwargs, valid_time):
+    """Apply a boolean mask to per-epoch ``bands`` and ``frequency`` arguments."""
+
+    temp_kwargs = kwargs.copy()
+
+    for key in ("frequency", "bands"):
+        if key not in temp_kwargs:
+            continue
+
+        values = np.asarray(temp_kwargs[key])
+
+        if values.ndim > 0 and values.shape[0] == valid_time.size:
+            temp_kwargs[key] = values[valid_time]
+
+    return temp_kwargs
+
 @citation_wrapper('redback')
 def t0_base_model(time, t0, **kwargs):
     """
@@ -34,17 +50,12 @@ def t0_base_model(time, t0, **kwargs):
     t0 = Time(t0, format='mjd')
     time = Time(np.asarray(time, dtype=float), format='mjd')
     time = (time - t0).to(uu.day).value
-    transient_time = time[time >= 0.0]
-    bad_time = time[time < 0.0]
+    valid_time = time >= 0.0
+    transient_time = time[valid_time]
+    bad_time = time[~valid_time]
     if kwargs['base_model'] in ['thin_shell_supernova', 'homologous_expansion_supernova']:
         kwargs['base_model'] = kwargs.get('submodel', 'arnett_bolometric')
-    temp_kwargs = kwargs.copy()
-    if 'frequency' in temp_kwargs:
-        if isinstance(temp_kwargs['frequency'], np.ndarray):
-            temp_kwargs['frequency'] = kwargs['frequency'][time >= 0.0]
-    if 'bands' in temp_kwargs:
-        if isinstance(temp_kwargs['bands'], np.ndarray):
-            temp_kwargs['bands'] = kwargs['bands'][time >= 0.0]
+    temp_kwargs = _mask_per_epoch_kwargs(kwargs, valid_time)
     output_real = function(transient_time, **temp_kwargs)
     if kwargs['output_format'] == 'magnitude':
         output_fake = np.zeros(len(bad_time)) + 1000
@@ -77,13 +88,7 @@ def _t0_with_extinction(time, t0, av_host, model_type='supernova', **kwargs):
     valid_time = time >= 0.0
     transient_time = time[valid_time]
     bad_time = time[~valid_time]
-    temp_kwargs = kwargs.copy()
-    if 'frequency' in temp_kwargs:
-        if isinstance(temp_kwargs['frequency'], np.ndarray):
-            temp_kwargs['frequency'] = kwargs['frequency'][valid_time]
-    if 'bands' in temp_kwargs:
-        if isinstance(temp_kwargs['bands'], np.ndarray):
-            temp_kwargs['bands'] = kwargs['bands'][valid_time]
+    temp_kwargs = _mask_per_epoch_kwargs(kwargs, valid_time)
     output_real = function(transient_time, av_host=av_host, **temp_kwargs)
     if kwargs['output_format'] == 'magnitude':
         output_fake = np.zeros(len(bad_time)) + 5000

--- a/test/extinction_test.py
+++ b/test/extinction_test.py
@@ -192,13 +192,10 @@ class TestExtinctionWithSupernovaBaseModel(unittest.TestCase):
 
 class TestT0WithExtinction(unittest.TestCase):
 
-    def test_masks_vector_kwargs_for_pre_t0_times(self):
-        """Vector kwargs should be masked with the post-t0 time array."""
+    def _assert_vector_kwargs_masked(self, bands, frequency):
         from redback.transient_models import phase_models
 
         time = np.array([59999.0, 60000.0, 60001.0])
-        bands = np.array(['pre', 'post0', 'post1'])
-        frequency = np.array([1.0, 2.0, 3.0])
 
         def dummy_extinction_model(time, av_host, **kwargs):
             np.testing.assert_array_equal(time, np.array([0.0, 1.0]))
@@ -209,9 +206,8 @@ class TestT0WithExtinction(unittest.TestCase):
             self.assertEqual(av_host, 0.2)
             return np.array([20.0, 21.0])
 
-        with mock.patch.dict(
-                phase_models.extinction_model_functions,
-                {'supernova': dummy_extinction_model}):
+        with mock.patch.dict(phase_models.extinction_model_functions,
+                             {'supernova': dummy_extinction_model}):
             result = phase_models.t0_supernova_extinction(
                 time=time,
                 t0=60000.0,
@@ -222,6 +218,38 @@ class TestT0WithExtinction(unittest.TestCase):
 
         np.testing.assert_array_equal(
             result, np.array([5000.0, 20.0, 21.0]))
+
+    def test_masks_numpy_array_kwargs_for_pre_t0_times(self):
+        self._assert_vector_kwargs_masked(
+            bands=np.array(["pre", "post0", "post1"]),
+            frequency=np.array([1.0, 2.0, 3.0]),
+        )
+
+    def test_masks_list_kwargs_for_pre_t0_times(self):
+        self._assert_vector_kwargs_masked(
+            bands=["pre", "post0", "post1"],
+            frequency=[1.0, 2.0, 3.0],
+        )
+
+    def test_does_not_mask_scalar_or_non_per_epoch_kwargs(self):
+        from redback.transient_models import phase_models
+
+        valid_time = np.array([False, True, True])
+
+        kwargs = {
+            "bands": "ztfr",
+            "frequency": [4.5e14],
+            "other_parameter": [1.0, 2.0, 3.0],
+        }
+
+        result = phase_models._mask_per_epoch_kwargs(
+            kwargs,
+            valid_time,
+        )
+
+        self.assertEqual(result["bands"], "ztfr")
+        self.assertEqual(result["frequency"], [4.5e14])
+        self.assertEqual(result["other_parameter"], [1.0, 2.0, 3.0])
 
 
 # ---------------------------------------------------------------------------

--- a/test/extinction_test.py
+++ b/test/extinction_test.py
@@ -187,6 +187,44 @@ class TestExtinctionWithSupernovaBaseModel(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# t0 extinction wrapper
+# ---------------------------------------------------------------------------
+
+class TestT0WithExtinction(unittest.TestCase):
+
+    def test_masks_vector_kwargs_for_pre_t0_times(self):
+        """Vector kwargs should be masked with the post-t0 time array."""
+        from redback.transient_models import phase_models
+
+        time = np.array([59999.0, 60000.0, 60001.0])
+        bands = np.array(['pre', 'post0', 'post1'])
+        frequency = np.array([1.0, 2.0, 3.0])
+
+        def dummy_extinction_model(time, av_host, **kwargs):
+            np.testing.assert_array_equal(time, np.array([0.0, 1.0]))
+            np.testing.assert_array_equal(
+                kwargs['bands'], np.array(['post0', 'post1']))
+            np.testing.assert_array_equal(
+                kwargs['frequency'], np.array([2.0, 3.0]))
+            self.assertEqual(av_host, 0.2)
+            return np.array([20.0, 21.0])
+
+        with mock.patch.dict(
+                phase_models.extinction_model_functions,
+                {'supernova': dummy_extinction_model}):
+            result = phase_models.t0_supernova_extinction(
+                time=time,
+                t0=60000.0,
+                av_host=0.2,
+                bands=bands,
+                frequency=frequency,
+                output_format='magnitude')
+
+        np.testing.assert_array_equal(
+            result, np.array([5000.0, 20.0, 21.0]))
+
+
+# ---------------------------------------------------------------------------
 # extinction_with_function
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`_t0_with_extinction()` previously filtered `time` to post-`t0` epochs but passed the original vector kwargs through unchanged. This PR makes its behavior consistent with `t0_base_model()` by applying the same post-`t0` mask to array-like `bands` and `frequency` arguments before evaluating the model.

Also included here is a new test to help ensure this behaves as it should.

Fixes #371.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Corrected extinction calculations when observations occur before the reference time.
- Kept per-observation frequency and band values aligned with the remaining valid observations.
- Preserved existing behavior for scalar values and parameters that do not vary by observation.

## Tests

- Added coverage for list and NumPy-array inputs.
- Added validation that scalar and non-per-observation parameters remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->