### PR TITLE
Document upper-limit errors and fix SNcosmo frequency validation

### DIFF
--- a/docs/likelihood.txt
+++ b/docs/likelihood.txt
@@ -114,8 +114,10 @@ appropriate when the supplied magnitude errors were themselves derived from appr
 flux-density errors. It currently handles detections only; use
 :code:`GaussianLikelihoodWithUpperLimits` for datasets containing upper limits.
 
+.. _non-detections-upper-limits:
+
 Non-detections / upper limits
--------------------------
+-----------------------------
 
 :code:`GaussianLikelihoodWithUpperLimits` handles datasets that mix genuine detections with
 non-detection upper limits. Each data point is flagged as a detection or upper limit via a boolean

--- a/docs/likelihood.txt
+++ b/docs/likelihood.txt
@@ -14,6 +14,7 @@ Regular likelihoods
 -------------------------
 
 - Gaussian likelihood - general Gaussian likelihood
+- Gaussian likelihood on magnitude flux (:code:`GaussianLikelihoodOnMagnitudeFlux`) - accepts AB magnitude data and a model that returns magnitudes, but evaluates the Gaussian likelihood after converting both to flux density
 - GRB Gaussian likelihood - a GRB specific Gaussian likelihood
 - Poisson likelihood - For a poisson process
 
@@ -70,6 +71,48 @@ If you don't like the likelihoods implemented in redback, you can write your own
                res = self.y - self.function(self.x, **self.parameters, **self.kwargs)
                return -0.5 * (np.sum((res / self.sigma)**2)
                               + self.N*np.log(2*np.pi*self.sigma**2))
+
+Gaussian likelihood for magnitude data in flux space
+-------------------------
+
+Photometric measurement noise is often approximately Gaussian in flux density rather than in
+magnitude. :code:`GaussianLikelihoodOnMagnitudeFlux` allows a transient and model to remain in
+Redback's :code:`magnitude` data mode while evaluating the residuals in AB flux density. The
+observed magnitudes and model magnitudes are converted to mJy internally, and magnitude errors are
+propagated as
+
+.. math::
+
+    \sigma_f = \frac{\ln 10}{2.5} f_\nu \sigma_m.
+
+Construct this likelihood explicitly and pass it to :code:`fit_model`:
+
+.. code:: python
+
+    from redback.likelihoods import GaussianLikelihoodOnMagnitudeFlux
+
+    likelihood = GaussianLikelihoodOnMagnitudeFlux(
+        x=transient.x,
+        y=transient.y,
+        sigma=transient.y_err,
+        function=model,
+        kwargs=model_kwargs,
+    )
+
+    result = redback.fit_model(
+        transient=transient,
+        model=model,
+        likelihood=likelihood,
+        prior=prior,
+        model_kwargs=model_kwargs,
+        ...
+    )
+
+The data and model must use AB magnitudes, and the magnitude uncertainties must be finite and
+positive. The uncertainty conversion is a local linear propagation, so this likelihood is most
+appropriate when the supplied magnitude errors were themselves derived from approximately Gaussian
+flux-density errors. It currently handles detections only; use
+:code:`GaussianLikelihoodWithUpperLimits` for datasets containing upper limits.
 
 Non-detections / upper limits
 -------------------------

--- a/docs/likelihood.txt
+++ b/docs/likelihood.txt
@@ -166,6 +166,7 @@ For example, when constructing a transient from a table with missing upper-limit
 For flux-like data, Redback uses :math:`\sigma_{\rm lim}=y_{\rm lim}/N` for an :math:`N`-sigma
 limit. For magnitudes it uses :math:`\sigma_{m,\rm lim}=(2.5/\ln 10)/N`. These are derived inside
 the upper-limit likelihood; the placeholder in :code:`errors` does not replace or modify them.
+Every value supplied through :code:`upper_limit_sigma` must be finite and strictly positive.
 
 Joint likelihoods
 -------------------------

--- a/docs/likelihood.txt
+++ b/docs/likelihood.txt
@@ -73,7 +73,7 @@ If you don't like the likelihoods implemented in redback, you can write your own
                               + self.N*np.log(2*np.pi*self.sigma**2))
 
 Gaussian likelihood for magnitude data in flux space
--------------------------
+----------------------------------------------------
 
 Photometric measurement noise is often approximately Gaussian in flux density rather than in
 magnitude. :code:`GaussianLikelihoodOnMagnitudeFlux` allows a transient and model to remain in

--- a/docs/likelihood.txt
+++ b/docs/likelihood.txt
@@ -130,6 +130,43 @@ You can also construct the likelihood manually:
 is substituted automatically. For manually constructed datasets, replace any NaN upper limit
 values with the actual limiting magnitude or flux before passing to the likelihood.
 
+The measurement-error array must have one entry per observation. Errors for detected points must
+be finite and positive because they enter the Gaussian likelihood directly. Errors attached to
+upper-limit points are not used by :code:`GaussianLikelihoodWithUpperLimits`: their effective
+uncertainty is calculated from the finite limit value and :code:`upper_limit_sigma`. Consequently,
+an upper-limit error may be NaN or infinite without changing this likelihood. A finite placeholder
+is nevertheless convenient when the same transient will also be passed to plotting code or a custom
+likelihood that expects every error to be finite.
+
+For example, when constructing a transient from a table with missing upper-limit uncertainties:
+
+.. code:: python
+
+    detections = np.asarray(detections, dtype=bool)
+    errors = np.asarray(errors, dtype=float)
+
+    invalid_detection_errors = detections & (~np.isfinite(errors) | (errors <= 0))
+    if np.any(invalid_detection_errors):
+        raise ValueError("Detected data require finite, positive uncertainties")
+
+    # This value is ignored for rows where detections is False.
+    errors[~detections] = 1.0
+
+    transient = redback.transient.Supernova(
+        name="my_supernova",
+        data_mode="flux_density",
+        time=time,
+        flux_density=flux_density,
+        flux_density_err=errors,
+        bands=bands,
+        detections=detections,
+        upper_limit_sigma=5.0,
+    )
+
+For flux-like data, Redback uses :math:`\sigma_{\rm lim}=y_{\rm lim}/N` for an :math:`N`-sigma
+limit. For magnitudes it uses :math:`\sigma_{m,\rm lim}=(2.5/\ln 10)/N`. These are derived inside
+the upper-limit likelihood; the placeholder in :code:`errors` does not replace or modify them.
+
 Joint likelihoods
 -------------------------
 

--- a/docs/transients.txt
+++ b/docs/transients.txt
@@ -153,6 +153,32 @@ Upper limit y-values must be finite. For non-detections, provide the limiting ma
 rather than NaN. When loading simulated data with :code:`include_upper_limits=True`, the limiting magnitude
 is substituted automatically.
 
+The measurement-error array must still contain one entry per observation. Errors for detected points must
+be finite and strictly positive because they enter the Gaussian likelihood. Errors for upper-limit points
+are not used by :code:`GaussianLikelihoodWithUpperLimits`; Redback calculates their effective uncertainty
+from the finite limit value and :code:`upper_limit_sigma`. An upper-limit error may therefore be NaN or
+infinite without changing this likelihood, although a finite placeholder is useful for plotting code or
+custom likelihoods that expect every error to be finite. For example:
+
+.. code:: python
+
+    detections = np.asarray(detections, dtype=bool)
+    mag_err = np.asarray(mag_err, dtype=float)
+
+    invalid_detection_errors = detections & (~np.isfinite(mag_err) | (mag_err <= 0))
+    if np.any(invalid_detection_errors):
+        raise ValueError("Detected data require finite, positive uncertainties")
+
+    # Ignored by the upper-limit likelihood for non-detection rows.
+    mag_err[~detections] = 1.0
+
+For flux-like data, an :math:`N`-sigma limit uses
+:math:`\sigma_{\rm lim}=y_{\rm lim}/N`; for magnitudes Redback uses
+:math:`\sigma_{m,\rm lim}=(2.5/\ln 10)/N`. Consequently, every scalar or array value supplied through
+:code:`upper_limit_sigma` must be finite and strictly positive. See
+:ref:`Non-detections / upper limits <non-detections-upper-limits>` for the likelihood calculation and a
+complete manual-construction example.
+
 In general, you can ignore the class methods and to create your own transient object by passing in the different attributes
 (time/flux/frequencies/bands) to the transient object of relevance.
 

--- a/redback/likelihoods.py
+++ b/redback/likelihoods.py
@@ -268,7 +268,6 @@ class GaussianLikelihoodOnMagnitudeFlux(GaussianLikelihood):
 
         self.magnitudes = magnitudes
         self.magnitude_sigma = magnitude_sigma
-        self._ab_zero_point_mjy = calc_flux_density_from_ABmag(0.0).value
         flux_density = self._magnitude_to_flux_density(magnitudes)
         flux_density_sigma = np.log(10.0) / 2.5 * flux_density * magnitude_sigma
         super().__init__(
@@ -276,7 +275,7 @@ class GaussianLikelihoodOnMagnitudeFlux(GaussianLikelihood):
             kwargs=kwargs, priors=priors, fiducial_parameters=fiducial_parameters)
 
     def _magnitude_to_flux_density(self, magnitude: np.ndarray) -> np.ndarray:
-        return self._ab_zero_point_mjy * np.power(10.0, -0.4 * np.asarray(magnitude))
+        return calc_flux_density_from_ABmag(magnitude).value
 
     @property
     def model_output(self) -> np.ndarray:

--- a/redback/likelihoods.py
+++ b/redback/likelihoods.py
@@ -283,16 +283,17 @@ class GaussianLikelihoodWithUpperLimits(GaussianLikelihood):
         self.upper_limit_sigma = upper_limit_sigma
         self.data_mode = data_mode
 
-        # Validate that upper limit y-values are finite (NaN upper limits are not usable for likelihood)
+        # Upper limits must identify a finite location for the likelihood CDF.
         if self._detections is not None and not np.all(self._detections):
             ul_y = self.y[~self._detections]
-            nan_ul = np.isnan(ul_y)
-            if np.any(nan_ul):
-                n_nan = int(np.sum(nan_ul))
+            invalid_ul = ~np.isfinite(ul_y)
+            if np.any(invalid_ul):
+                n_invalid = int(np.sum(invalid_ul))
                 raise ValueError(
-                    f"{n_nan} upper limit(s) have NaN y-values. Upper limits require a finite "
+                    f"{n_invalid} upper limit(s) have non-finite (NaN or infinite) y-values. "
+                    f"Upper limits require a finite "
                     f"value (e.g. the limiting magnitude or flux) to compute likelihood. "
-                    f"Replace NaN values with the upper limit value, or remove those data points."
+                    f"Replace non-finite values with the upper limit value, or remove those data points."
                 )
 
     @property
@@ -320,9 +321,14 @@ class GaussianLikelihoodWithUpperLimits(GaussianLikelihood):
 
     @upper_limit_sigma.setter
     def upper_limit_sigma(self, upper_limit_sigma: Union[float, np.ndarray]) -> None:
-        if isinstance(upper_limit_sigma, (float, int)):
-            self._upper_limit_sigma = float(upper_limit_sigma)
+        if isinstance(upper_limit_sigma, (float, int, np.floating, np.integer)):
+            value = float(upper_limit_sigma)
+            if not np.isfinite(value) or value <= 0:
+                raise ValueError('upper_limit_sigma must contain only finite, positive values.')
+            self._upper_limit_sigma = value
         elif isinstance(upper_limit_sigma, np.ndarray):
+            if not np.all(np.isfinite(upper_limit_sigma)) or np.any(upper_limit_sigma <= 0):
+                raise ValueError('upper_limit_sigma must contain only finite, positive values.')
             if len(upper_limit_sigma) == len(self.x):
                 self._upper_limit_sigma = upper_limit_sigma
             elif hasattr(self, '_detections') and len(upper_limit_sigma) == np.sum(~self._detections):

--- a/redback/likelihoods.py
+++ b/redback/likelihoods.py
@@ -3,7 +3,7 @@ from typing import Any, Union
 
 import bilby
 from scipy.special import gammaln, erf
-from redback.utils import logger
+from redback.utils import calc_flux_density_from_ABmag, logger
 from bilby.core.prior import DeltaFunction, Constraint
 
 
@@ -229,6 +229,68 @@ class GaussianLikelihood(_RedbackLikelihood):
     @staticmethod
     def _gaussian_log_likelihood(res: np.ndarray, sigma: Union[float, np.ndarray]) -> Any:
         return np.sum(- (res / sigma) ** 2 / 2 - np.log(2 * np.pi * sigma ** 2) / 2)
+
+
+class GaussianLikelihoodOnMagnitudeFlux(GaussianLikelihood):
+    """Evaluate an AB-magnitude model with a Gaussian likelihood in flux density.
+
+    The input data, uncertainties, and model output are AB magnitudes. They are
+    converted internally to mJy, with magnitude uncertainties propagated using
+    the local derivative of the AB magnitude relation. This is useful when the
+    measurement noise is approximately Gaussian in flux density but the model
+    is configured with ``output_format='magnitude'``.
+    """
+
+    def __init__(
+            self, x: np.ndarray, y: np.ndarray, sigma: Union[float, np.ndarray],
+            function: callable, kwargs: dict = None, priors=None,
+            fiducial_parameters=None) -> None:
+        """
+        :param x: The x values.
+        :param y: The observed AB magnitudes.
+        :param sigma: The one-sigma magnitude uncertainties.
+        :param function: A model that returns AB magnitudes.
+        :param kwargs: Any additional keywords for ``function``.
+        :param priors: Priors used by maximum likelihood estimation functionality.
+        :param fiducial_parameters: Starting values for maximum likelihood estimation.
+        """
+        magnitudes = np.asarray(y, dtype=float)
+        magnitude_sigma = np.asarray(sigma, dtype=float)
+        if magnitudes.ndim != 1:
+            raise ValueError('y must be a one-dimensional array of AB magnitudes.')
+        if magnitude_sigma.ndim > 1 or (
+                magnitude_sigma.ndim == 1 and len(magnitude_sigma) != len(magnitudes)):
+            raise ValueError('sigma must be a scalar or have the same length as y.')
+        if not np.all(np.isfinite(magnitudes)):
+            raise ValueError('y must contain only finite AB magnitudes.')
+        if not np.all(np.isfinite(magnitude_sigma)) or np.any(magnitude_sigma <= 0):
+            raise ValueError('sigma must contain only finite, positive magnitude uncertainties.')
+
+        self.magnitudes = magnitudes
+        self.magnitude_sigma = magnitude_sigma
+        self._ab_zero_point_mjy = calc_flux_density_from_ABmag(0.0).value
+        flux_density = self._magnitude_to_flux_density(magnitudes)
+        flux_density_sigma = np.log(10.0) / 2.5 * flux_density * magnitude_sigma
+        super().__init__(
+            x=x, y=flux_density, sigma=flux_density_sigma, function=function,
+            kwargs=kwargs, priors=priors, fiducial_parameters=fiducial_parameters)
+
+    def _magnitude_to_flux_density(self, magnitude: np.ndarray) -> np.ndarray:
+        return self._ab_zero_point_mjy * np.power(10.0, -0.4 * np.asarray(magnitude))
+
+    @property
+    def model_output(self) -> np.ndarray:
+        model_magnitude = self.function(self.x, **self.parameters, **self.kwargs)
+        return self._magnitude_to_flux_density(model_magnitude)
+
+    def log_likelihood(self, parameters=None) -> float:
+        self._update_parameters(parameters)
+        model_output = self.model_output
+        if not np.all(np.isfinite(model_output)):
+            return -np.inf
+        log_likelihood = self._gaussian_log_likelihood(
+            res=self.y - model_output, sigma=self.sigma)
+        return float(log_likelihood) if np.isfinite(log_likelihood) else -np.inf
 
 
 class GaussianLikelihoodWithUpperLimits(GaussianLikelihood):

--- a/redback/multimessenger.py
+++ b/redback/multimessenger.py
@@ -415,10 +415,10 @@ class MultiMessengerTransient:
                 )
             n_upper_limits = int(np.sum(~detections))
             upper_limit_y = y[~detections]
-            n_nan_upper_limits = int(np.sum(np.isnan(upper_limit_y)))
-            if n_nan_upper_limits > 0:
+            n_invalid_upper_limits = int(np.sum(~np.isfinite(upper_limit_y)))
+            if n_invalid_upper_limits > 0:
                 logger.warning(
-                    f"{n_nan_upper_limits} upper limit(s) for {messenger} have NaN y-values and "
+                    f"{n_invalid_upper_limits} upper limit(s) for {messenger} have non-finite y-values and "
                     "cannot be used in GaussianLikelihoodWithUpperLimits. Falling back to a "
                     "GaussianLikelihood using detection data only."
                 )

--- a/redback/sampler.py
+++ b/redback/sampler.py
@@ -371,12 +371,12 @@ def _fit_optical_transient(transient, model, outdir, label, likelihood=None, sam
             n_ul = int(np.sum(~detections))
             # Check that upper limit y-values are finite
             ul_y = y[~detections]
-            n_nan_ul = int(np.sum(np.isnan(ul_y)))
-            if n_nan_ul > 0:
+            n_invalid_ul = int(np.sum(~np.isfinite(ul_y)))
+            if n_invalid_ul > 0:
                 logger.warning(
-                    f"{n_nan_ul} upper limit(s) have NaN y-values, which cannot be used in "
+                    f"{n_invalid_ul} upper limit(s) have non-finite y-values, which cannot be used in "
                     f"GaussianLikelihoodWithUpperLimits. Falling back to standard GaussianLikelihood "
-                    f"with detection data only. Replace NaN values with the upper limit value "
+                    f"with detection data only. Replace non-finite values with the upper limit value "
                     f"(e.g. limiting magnitude or flux) to use upper limit likelihood."
                 )
                 # Filter to detection-only data for standard likelihood

--- a/redback/transient/transient.py
+++ b/redback/transient/transient.py
@@ -894,17 +894,17 @@ class Transient(object):
         are not usable because there is no position to draw the marker at,
         and the likelihood cannot evaluate the CDF without a numerical limit.
 
-        Logs a warning for each band with NaN upper limits.
+        Logs a warning when upper limits are NaN or infinite.
         """
         if self._detections is None or not self.has_upper_limits:
             return
         ul_mask = self.upper_limits
         ul_y = self.y[ul_mask]
-        nan_count = np.sum(np.isnan(ul_y))
-        if nan_count > 0:
+        invalid_count = np.sum(~np.isfinite(ul_y))
+        if invalid_count > 0:
             redback.utils.logger.warning(
-                f"{int(nan_count)} upper limit(s) have NaN y-values. These cannot be "
-                f"plotted or used in likelihood fitting. Replace NaN values with the "
+                f"{int(invalid_count)} upper limit(s) have non-finite y-values. These cannot be "
+                f"plotted or used in likelihood fitting. Replace non-finite values with the "
                 f"upper limit value (e.g. the limiting magnitude or flux), or remove "
                 f"those data points."
             )

--- a/redback/transient_models/kilonova_models.py
+++ b/redback/transient_models/kilonova_models.py
@@ -1641,11 +1641,15 @@ def _kilonova_diffusion_luminosity(time, thermalised_luminosity, diffusion_times
     diffusion_system = np.zeros((2, len(time)))
     diffusion_system[0] = 1.0
     diffusion_system[1, :-1] = -decay
-    bolometric_luminosity = solve_banded(
-        (1, 0), diffusion_system, bolometric_luminosity, check_finite=False
+    nonfinite_indices = np.flatnonzero(~np.isfinite(bolometric_luminosity))
+    finite_prefix_length = nonfinite_indices[0] if len(nonfinite_indices) else len(time)
+    bolometric_luminosity[:finite_prefix_length] = solve_banded(
+        (1, 0), diffusion_system[:, :finite_prefix_length],
+        bolometric_luminosity[:finite_prefix_length], check_finite=False
     )
+    bolometric_luminosity[finite_prefix_length:] = np.nan
 
-    if len(time) > 1:
+    if finite_prefix_length > 1:
         # Match the historical treatment of the first grid point.
         bolometric_luminosity[0] = bolometric_luminosity[1] * np.exp(
             scaled_time_squared[1] - scaled_time_squared[0]

--- a/redback/transient_models/kilonova_models.py
+++ b/redback/transient_models/kilonova_models.py
@@ -3,8 +3,8 @@ import pandas as pd
 
 from astropy.table import Table, Column
 from scipy.interpolate import interp1d, RegularGridInterpolator
+from scipy.linalg import solve_banded
 from astropy.cosmology import Planck18 as cosmo  # noqa
-from scipy.integrate import cumulative_trapezoid
 from collections import namedtuple
 
 import redback.utils
@@ -1624,6 +1624,34 @@ def _calc_new_heating_rate(time, mej, electron_fraction, ejecta_velocity, **kwar
     lum_in = qdot_in * m0
     return lum_in * heating_rate_perturbation
 
+
+def _kilonova_diffusion_luminosity(time, thermalised_luminosity, diffusion_timescale):
+    """Evaluate the kilonova diffusion convolution without exponential overflow."""
+    time = np.asarray(time, dtype=float)
+    thermalised_luminosity = np.asarray(thermalised_luminosity, dtype=float)
+    bolometric_luminosity = np.zeros_like(time)
+
+    inverse_tdiff_squared = diffusion_timescale ** -2
+    scaled_time_squared = time ** 2 * inverse_tdiff_squared
+    decay = np.exp(-np.diff(scaled_time_squared))
+    bolometric_luminosity[1:] = 0.5 * np.diff(time) * inverse_tdiff_squared * (
+        decay * thermalised_luminosity[:-1] * time[:-1]
+        + thermalised_luminosity[1:] * time[1:]
+    )
+    diffusion_system = np.zeros((2, len(time)))
+    diffusion_system[0] = 1.0
+    diffusion_system[1, :-1] = -decay
+    bolometric_luminosity = solve_banded(
+        (1, 0), diffusion_system, bolometric_luminosity, check_finite=False
+    )
+
+    if len(time) > 1:
+        # Match the historical treatment of the first grid point.
+        bolometric_luminosity[0] = bolometric_luminosity[1] * np.exp(
+            scaled_time_squared[1] - scaled_time_squared[0]
+        )
+    return bolometric_luminosity
+
 def _calculate_rosswogkorobkin24_qdot_formula(time_array, e0, alp, t0, sig, alp1,
                             t1, sig1, c1, tau1, c2, tau2, c3, tau3):
     time = time_array
@@ -1656,12 +1684,7 @@ def _one_component_kilonova_rosswog_heatingrate(time, mej, vej, electron_fractio
     tdiff = np.sqrt(2.0 * kappa * (m0) / (beta * v0 * speed_of_light))
 
     lum_in = _calc_new_heating_rate(time, mej, electron_fraction, vej, **kwargs)
-    integrand = lum_in * e_th * (time / tdiff) * np.exp(time ** 2 / tdiff ** 2)
-
-    bolometric_luminosity = np.zeros(len(time))
-    bolometric_luminosity[1:] = cumulative_trapezoid(integrand, time)
-    bolometric_luminosity[0] = bolometric_luminosity[1]
-    bolometric_luminosity = bolometric_luminosity * np.exp(-time ** 2 / tdiff ** 2) / tdiff
+    bolometric_luminosity = _kilonova_diffusion_luminosity(time, lum_in * e_th, tdiff)
 
     temperature = (bolometric_luminosity / (4.0 * np.pi * sigma_sb * v0 ** 2 * time ** 2)) ** 0.25
     r_photosphere = (bolometric_luminosity / (4.0 * np.pi * sigma_sb * temperature_floor ** 4)) ** 0.5
@@ -1882,11 +1905,7 @@ def _one_component_kilonova_model(time, mej, vej, kappa, **kwargs):
     m0 = mej * solar_mass
     tdiff = np.sqrt(2.0 * kappa * (m0) / (beta * v0 * speed_of_light))
     lum_in = 4.0e18 * (m0) * (0.5 - np.arctan((time - t0) / sig) / np.pi)**1.3
-    integrand = lum_in * e_th * (time/tdiff) * np.exp(time**2/tdiff**2)
-    bolometric_luminosity = np.zeros(len(time))
-    bolometric_luminosity[1:] = cumulative_trapezoid(integrand, time)
-    bolometric_luminosity[0] = bolometric_luminosity[1]
-    bolometric_luminosity = bolometric_luminosity * np.exp(-time**2/tdiff**2) / tdiff
+    bolometric_luminosity = _kilonova_diffusion_luminosity(time, lum_in * e_th, tdiff)
 
     temperature = (bolometric_luminosity / (4.0 * np.pi * sigma_sb * v0**2 * time**2))**0.25
     r_photosphere = (bolometric_luminosity / (4.0 * np.pi * sigma_sb * temperature_floor**4))**0.5

--- a/redback/transient_models/kilonova_models.py
+++ b/redback/transient_models/kilonova_models.py
@@ -1641,12 +1641,15 @@ def _kilonova_diffusion_luminosity(time, thermalised_luminosity, diffusion_times
     diffusion_system = np.zeros((2, len(time)))
     diffusion_system[0] = 1.0
     diffusion_system[1, :-1] = -decay
-    nonfinite_indices = np.flatnonzero(~np.isfinite(bolometric_luminosity))
-    finite_prefix_length = nonfinite_indices[0] if len(nonfinite_indices) else len(time)
-    bolometric_luminosity[:finite_prefix_length] = solve_banded(
-        (1, 0), diffusion_system[:, :finite_prefix_length],
-        bolometric_luminosity[:finite_prefix_length], check_finite=False
+    nonfinite_indices = np.flatnonzero(
+        ~np.isfinite(bolometric_luminosity) | ~np.isfinite(thermalised_luminosity)
     )
+    finite_prefix_length = nonfinite_indices[0] if len(nonfinite_indices) else len(time)
+    if finite_prefix_length:
+        bolometric_luminosity[:finite_prefix_length] = solve_banded(
+            (1, 0), diffusion_system[:, :finite_prefix_length],
+            bolometric_luminosity[:finite_prefix_length], check_finite=False
+        )
     bolometric_luminosity[finite_prefix_length:] = np.nan
 
     if finite_prefix_length > 1:

--- a/redback/transient_models/supernova_models.py
+++ b/redback/transient_models/supernova_models.py
@@ -80,30 +80,24 @@ def sncosmo_models(time, redshift, model_kwargs=None, **kwargs):
         model.set_source_peakabsmag(peak_abs_mag, band=peak_abs_mag_band, magsys=magsystem, cosmo=cosmology)
 
     if kwargs['output_format'] == 'flux_density':
-        frequency = kwargs['frequency']
-
-        if isinstance(frequency, float):
-            frequency = np.array([frequency])
-
-        if (len(frequency) != 1 or len(frequency) == len(time)):
+        time_array = np.atleast_1d(np.asarray(time, dtype=float))
+        frequency = np.atleast_1d(np.asarray(kwargs['frequency'], dtype=float))
+        if len(frequency) not in (1, len(time_array)):
             raise ValueError('frequency array must be of length 1 or same size as time array')
 
         unique_frequency = np.sort(np.unique(frequency))
         angstroms = nu_to_lambda(unique_frequency)
-
-        _flux = model.flux(time, angstroms)
+        flux_lambda = model.flux(time_array, angstroms)
 
         if len(frequency) > 1:
-            _flux = pd.DataFrame(_flux)
-            _flux.columns = unique_frequency
-            _flux = np.array([_flux[freq].iloc[i] for i, freq in enumerate(frequency)])
+            flux_lambda = pd.DataFrame(flux_lambda)
+            flux_lambda.columns = unique_frequency
+            flux_lambda = np.array([
+                flux_lambda[freq].iloc[i] for i, freq in enumerate(frequency)])
 
         units = uu.erg / uu.s / uu.Hz / uu.cm ** 2.
-        _flux = _flux * nu_to_lambda(frequency)
-        _flux = _flux / frequency
-        _flux = _flux << units
-
-        flux_density = _flux.to(uu.mJy).flatten()
+        flux_nu = flux_lambda * nu_to_lambda(frequency) / frequency
+        flux_density = (flux_nu << units).to(uu.mJy).flatten()
         return flux_density
 
     if kwargs['output_format'] == 'flux':

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -4,6 +4,7 @@ import unittest
 from unittest import mock
 
 from redback import likelihoods
+from redback.utils import calc_flux_density_from_ABmag
 
 
 class GaussianLikelihoodTest(unittest.TestCase):
@@ -71,6 +72,66 @@ class GaussianLikelihoodTest(unittest.TestCase):
     def test_residual(self):
         expected = self.x - self.y
         self.assertTrue(np.array_equal(expected, self.likelihood.residual))
+
+
+class GaussianLikelihoodOnMagnitudeFluxTest(unittest.TestCase):
+
+    def setUp(self):
+        self.x = np.array([0.0, 1.0, 2.0])
+        self.magnitudes = np.array([20.0, 20.5, 21.0])
+        self.magnitude_errors = np.array([0.1, 0.2, 0.15])
+
+        def function(x, offset, **kwargs):
+            return self.magnitudes + offset
+
+        self.function = function
+        self.likelihood = likelihoods.GaussianLikelihoodOnMagnitudeFlux(
+            x=self.x, y=self.magnitudes, sigma=self.magnitude_errors,
+            function=self.function)
+        self.likelihood.parameters['offset'] = 0.0
+
+    def test_converts_data_and_model_to_ab_flux_density(self):
+        expected_flux_density = calc_flux_density_from_ABmag(self.magnitudes).value
+        expected_sigma = (
+            np.log(10.0) / 2.5 * expected_flux_density * self.magnitude_errors)
+
+        np.testing.assert_allclose(self.likelihood.y, expected_flux_density)
+        np.testing.assert_allclose(self.likelihood.sigma, expected_sigma)
+        np.testing.assert_allclose(self.likelihood.model_output, expected_flux_density)
+
+    def test_matches_gaussian_likelihood_on_converted_flux_density(self):
+        self.likelihood.parameters['offset'] = 0.2
+        control = likelihoods.GaussianLikelihood(
+            x=self.x, y=self.likelihood.y, sigma=self.likelihood.sigma,
+            function=lambda x: self.likelihood.model_output)
+
+        self.assertAlmostEqual(
+            self.likelihood.log_likelihood(), control.log_likelihood())
+
+    def test_scalar_magnitude_error(self):
+        likelihood = likelihoods.GaussianLikelihoodOnMagnitudeFlux(
+            x=self.x, y=self.magnitudes, sigma=0.1, function=self.function)
+
+        expected = np.log(10.0) / 2.5 * likelihood.y * 0.1
+        np.testing.assert_allclose(likelihood.sigma, expected)
+
+    def test_rejects_invalid_data_uncertainties(self):
+        for sigma in (0.0, -0.1, np.nan, np.inf):
+            with self.subTest(sigma=sigma), self.assertRaises(ValueError):
+                likelihoods.GaussianLikelihoodOnMagnitudeFlux(
+                    x=self.x, y=self.magnitudes, sigma=sigma,
+                    function=self.function)
+
+    def test_non_finite_model_returns_negative_infinity(self):
+        def invalid_function(x, offset, **kwargs):
+            return np.full_like(x, np.nan)
+
+        likelihood = likelihoods.GaussianLikelihoodOnMagnitudeFlux(
+            x=self.x, y=self.magnitudes, sigma=self.magnitude_errors,
+            function=invalid_function)
+        likelihood.parameters['offset'] = 0.0
+
+        self.assertEqual(likelihood.log_likelihood(), -np.inf)
 
 
 class GaussianLikelihoodUniformXErrorsTest(unittest.TestCase):

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -402,16 +402,28 @@ class GaussianLikelihoodWithUpperLimitsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.likelihood.upper_limit_sigma = np.array([1.0, 2.0, 3.0])
 
-    def test_nan_upper_limit_rejected(self):
-        """Test that NaN y-values for upper limits raise ValueError"""
-        y_with_nan = np.array([0.5, 1.2, 2.1, np.nan, np.nan])
-        with self.assertRaises(ValueError) as ctx:
-            likelihoods.GaussianLikelihoodWithUpperLimits(
-                x=self.x, y=y_with_nan, sigma=self.sigma, function=self.function,
-                detections=self.detections, upper_limit_sigma=self.upper_limit_sigma,
-                kwargs=self.kwargs)
-        self.assertIn("NaN", str(ctx.exception))
-        self.assertIn("upper limit", str(ctx.exception))
+    def test_nonfinite_upper_limit_rejected(self):
+        """NaN and infinite upper-limit values cannot define a likelihood CDF."""
+        for invalid_value in (np.nan, np.inf, -np.inf):
+            with self.subTest(invalid_value=invalid_value):
+                y_with_invalid_limit = self.y.copy()
+                y_with_invalid_limit[-1] = invalid_value
+                with self.assertRaisesRegex(ValueError, 'upper limit.*non-finite|non-finite.*upper limit'):
+                    likelihoods.GaussianLikelihoodWithUpperLimits(
+                        x=self.x, y=y_with_invalid_limit, sigma=self.sigma,
+                        function=self.function, detections=self.detections,
+                        upper_limit_sigma=self.upper_limit_sigma, kwargs=self.kwargs)
+
+    def test_upper_limit_sigma_rejects_nonfinite_or_nonpositive_values(self):
+        invalid_values = (
+            0.0, -1.0, np.nan, np.inf, -np.inf,
+            np.array([2.0, 0.0]), np.array([2.0, -1.0]),
+            np.array([2.0, np.nan]), np.array([2.0, np.inf]),
+        )
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, 'finite, positive'):
+                    self.likelihood.upper_limit_sigma = invalid_value
 
     def test_nonfinite_measurement_errors_are_ignored_for_upper_limits(self):
         """Upper-limit uncertainty comes from the limit and upper_limit_sigma."""
@@ -421,9 +433,21 @@ class GaussianLikelihoodWithUpperLimitsTest(unittest.TestCase):
             x=self.x, y=self.y, sigma=sigma, function=self.function,
             detections=self.detections, upper_limit_sigma=self.upper_limit_sigma,
             kwargs=self.kwargs)
+        control_sigma = self.sigma.copy()
+        control_sigma[~self.detections] = 1.0
+        control = likelihoods.GaussianLikelihoodWithUpperLimits(
+            x=self.x, y=self.y, sigma=control_sigma, function=self.function,
+            detections=self.detections, upper_limit_sigma=self.upper_limit_sigma,
+            kwargs=self.kwargs)
 
-        self.assertTrue(np.isfinite(likelihood.log_likelihood({'param_1': 1.0})))
-        self.assertTrue(np.isfinite(likelihood.noise_log_likelihood()))
+        log_likelihood = likelihood.log_likelihood({'param_1': 1.0})
+        control_log_likelihood = control.log_likelihood({'param_1': 1.0})
+        noise_log_likelihood = likelihood.noise_log_likelihood()
+        control_noise_log_likelihood = control.noise_log_likelihood()
+        self.assertTrue(np.isfinite(log_likelihood))
+        self.assertTrue(np.isfinite(noise_log_likelihood))
+        self.assertAlmostEqual(log_likelihood, control_log_likelihood)
+        self.assertAlmostEqual(noise_log_likelihood, control_noise_log_likelihood)
 
     def test_data_mode_validation(self):
         """Test that data_mode setter validates allowed values"""

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -413,6 +413,18 @@ class GaussianLikelihoodWithUpperLimitsTest(unittest.TestCase):
         self.assertIn("NaN", str(ctx.exception))
         self.assertIn("upper limit", str(ctx.exception))
 
+    def test_nonfinite_measurement_errors_are_ignored_for_upper_limits(self):
+        """Upper-limit uncertainty comes from the limit and upper_limit_sigma."""
+        sigma = self.sigma.copy()
+        sigma[~self.detections] = [np.nan, np.inf]
+        likelihood = likelihoods.GaussianLikelihoodWithUpperLimits(
+            x=self.x, y=self.y, sigma=sigma, function=self.function,
+            detections=self.detections, upper_limit_sigma=self.upper_limit_sigma,
+            kwargs=self.kwargs)
+
+        self.assertTrue(np.isfinite(likelihood.log_likelihood({'param_1': 1.0})))
+        self.assertTrue(np.isfinite(likelihood.noise_log_likelihood()))
+
     def test_data_mode_validation(self):
         """Test that data_mode setter validates allowed values"""
         self.likelihood.data_mode = 'flux_density'

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -2272,6 +2272,23 @@ class TestOptimalTimeArray(unittest.TestCase):
 
         self.assertTrue(np.all(np.isfinite(flux_density)))
         self.assertTrue(np.all(flux_density >= 0.0))
+
+    def test_kilonova_diffusion_does_not_propagate_late_nan_backwards(self):
+        from redback.transient_models.kilonova_models import _kilonova_diffusion_luminosity
+
+        time = np.geomspace(1.0e-2, 2.0e5, 200)
+        thermalised_luminosity = 1.0e42 * np.exp(-time / 1.0e5)
+        finite_result = _kilonova_diffusion_luminosity(
+            time, thermalised_luminosity, 4.0e5
+        )
+        thermalised_luminosity[150:] = np.nan
+
+        result = _kilonova_diffusion_luminosity(
+            time, thermalised_luminosity, 4.0e5
+        )
+
+        np.testing.assert_allclose(result[:150], finite_result[:150])
+        self.assertTrue(np.all(np.isnan(result[150:])))
     
     def test_basic_functionality(self):
         """Test that the function returns an array of the correct length."""

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -97,6 +97,22 @@ class TestSncosmoModels(unittest.TestCase):
         np.testing.assert_allclose(result.to(uu.mJy).value, expected)
 
     @patch('sncosmo.Model')
+    def test_flux_density_accepts_python_float_frequency(self, model_class):
+        model_class.return_value = self._mock_model([[1.0], [2.0], [3.0]])
+        time = np.array([1.0, 2.0, 3.0])
+        frequency = 4.0e14
+
+        result = sncosmo_models(
+            time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
+            output_format='flux_density', host_extinction=False, mw_extinction=False)
+
+        expected_flux_nu = np.array([1.0, 2.0, 3.0]) * nu_to_lambda(frequency) / frequency
+        expected = (
+            expected_flux_nu << (uu.erg / uu.s / uu.Hz / uu.cm ** 2)
+        ).to(uu.mJy).value
+        np.testing.assert_allclose(result.to(uu.mJy).value, expected)
+
+    @patch('sncosmo.Model')
     def test_flux_density_rejects_mismatched_frequency_array(self, model_class):
         model_class.return_value = self._mock_model([[1.0]])
         with self.assertRaisesRegex(ValueError, 'length 1 or same size as time array'):

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -2289,6 +2289,19 @@ class TestOptimalTimeArray(unittest.TestCase):
 
         np.testing.assert_allclose(result[:150], finite_result[:150])
         self.assertTrue(np.all(np.isnan(result[150:])))
+
+    def test_kilonova_diffusion_is_invalid_from_nonfinite_first_input(self):
+        from redback.transient_models.kilonova_models import _kilonova_diffusion_luminosity
+
+        time = np.geomspace(1.0e-2, 2.0e5, 200)
+        thermalised_luminosity = 1.0e42 * np.exp(-time / 1.0e5)
+        thermalised_luminosity[0] = np.nan
+
+        result = _kilonova_diffusion_luminosity(
+            time, thermalised_luminosity, 4.0e5
+        )
+
+        self.assertTrue(np.all(np.isnan(result)))
     
     def test_basic_functionality(self):
         """Test that the function returns an array of the correct length."""

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -45,8 +45,65 @@ def _network_available():
 
 
 import redback.model_library
+from redback.transient_models.supernova_models import sncosmo_models
+from redback.utils import nu_to_lambda
 
 _dirname = dirname(__file__)
+
+
+class TestSncosmoModels(unittest.TestCase):
+
+    @staticmethod
+    def _mock_model(flux_lambda):
+        model = MagicMock()
+        model.flux.return_value = np.asarray(flux_lambda, dtype=float)
+        return model
+
+    @patch('sncosmo.Model')
+    def test_flux_density_accepts_frequency_per_epoch(self, model_class):
+        model_class.return_value = self._mock_model([
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+        ])
+        time = np.array([1.0, 2.0, 3.0])
+        frequency = np.array([4.0e14, 5.0e14, 4.0e14])
+
+        result = sncosmo_models(
+            time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
+            output_format='flux_density', host_extinction=False, mw_extinction=False)
+
+        selected_flux_lambda = np.array([1.0, 4.0, 5.0])
+        expected_flux_nu = selected_flux_lambda * nu_to_lambda(frequency) / frequency
+        expected = (
+            expected_flux_nu << (uu.erg / uu.s / uu.Hz / uu.cm ** 2)
+        ).to(uu.mJy).value
+        np.testing.assert_allclose(result.to(uu.mJy).value, expected)
+
+    @patch('sncosmo.Model')
+    def test_flux_density_accepts_numpy_scalar_frequency(self, model_class):
+        model_class.return_value = self._mock_model([[1.0], [2.0], [3.0]])
+        time = np.array([1.0, 2.0, 3.0])
+        frequency = np.float64(4.0e14)
+
+        result = sncosmo_models(
+            time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
+            output_format='flux_density', host_extinction=False, mw_extinction=False)
+
+        expected_flux_nu = np.array([1.0, 2.0, 3.0]) * nu_to_lambda(frequency) / frequency
+        expected = (
+            expected_flux_nu << (uu.erg / uu.s / uu.Hz / uu.cm ** 2)
+        ).to(uu.mJy).value
+        np.testing.assert_allclose(result.to(uu.mJy).value, expected)
+
+    @patch('sncosmo.Model')
+    def test_flux_density_rejects_mismatched_frequency_array(self, model_class):
+        model_class.return_value = self._mock_model([[1.0]])
+        with self.assertRaisesRegex(ValueError, 'length 1 or same size as time array'):
+            sncosmo_models(
+                time=np.array([1.0, 2.0, 3.0]), redshift=0.1, model_kwargs={},
+                frequency=np.array([4.0e14, 5.0e14]), output_format='flux_density',
+                host_extinction=False, mw_extinction=False)
 
 
 class TestCSMNickelBolometric(unittest.TestCase):

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -73,6 +73,10 @@ class TestSncosmoModels(unittest.TestCase):
             time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
             output_format='flux_density', host_extinction=False, mw_extinction=False)
 
+        model_class.return_value.flux.assert_called_once()
+        evaluated_wavelengths = model_class.return_value.flux.call_args.args[1]
+        np.testing.assert_allclose(
+            evaluated_wavelengths, nu_to_lambda(np.sort(np.unique(frequency))))
         selected_flux_lambda = np.array([1.0, 4.0, 5.0])
         expected_flux_nu = selected_flux_lambda * nu_to_lambda(frequency) / frequency
         expected = (
@@ -90,6 +94,9 @@ class TestSncosmoModels(unittest.TestCase):
             time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
             output_format='flux_density', host_extinction=False, mw_extinction=False)
 
+        model_class.return_value.flux.assert_called_once()
+        evaluated_wavelengths = model_class.return_value.flux.call_args.args[1]
+        np.testing.assert_allclose(evaluated_wavelengths, nu_to_lambda(frequency))
         expected_flux_nu = np.array([1.0, 2.0, 3.0]) * nu_to_lambda(frequency) / frequency
         expected = (
             expected_flux_nu << (uu.erg / uu.s / uu.Hz / uu.cm ** 2)
@@ -106,6 +113,9 @@ class TestSncosmoModels(unittest.TestCase):
             time=time, redshift=0.1, model_kwargs={}, frequency=frequency,
             output_format='flux_density', host_extinction=False, mw_extinction=False)
 
+        model_class.return_value.flux.assert_called_once()
+        evaluated_wavelengths = model_class.return_value.flux.call_args.args[1]
+        np.testing.assert_allclose(evaluated_wavelengths, nu_to_lambda(frequency))
         expected_flux_nu = np.array([1.0, 2.0, 3.0]) * nu_to_lambda(frequency) / frequency
         expected = (
             expected_flux_nu << (uu.erg / uu.s / uu.Hz / uu.cm ** 2)

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -2233,6 +2233,45 @@ class TestCosmologicalCorrections(unittest.TestCase):
 
 class TestOptimalTimeArray(unittest.TestCase):
     """Test suite for the get_optimal_time_array utility function."""
+
+    def test_kilonova_diffusion_matches_finite_legacy_calculation(self):
+        from redback.transient_models.kilonova_models import _kilonova_diffusion_luminosity
+
+        time = np.geomspace(1.0e-2, 2.0e5, 200)
+        thermalised_luminosity = 1.0e42 * np.exp(-time / 1.0e5)
+        diffusion_timescale = 4.0e5
+        integrand = (
+            thermalised_luminosity * (time / diffusion_timescale)
+            * np.exp(time ** 2 / diffusion_timescale ** 2)
+        )
+        cumulative_integral = np.zeros_like(time)
+        cumulative_integral[1:] = np.cumsum(
+            0.5 * (integrand[:-1] + integrand[1:]) * np.diff(time)
+        )
+        cumulative_integral[0] = cumulative_integral[1]
+        expected = (
+            cumulative_integral * np.exp(-time ** 2 / diffusion_timescale ** 2)
+            / diffusion_timescale
+        )
+
+        actual = _kilonova_diffusion_luminosity(
+            time, thermalised_luminosity, diffusion_timescale
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=2.0e-14)
+
+    def test_kilonova_diffusion_is_finite_for_extreme_valid_prior(self):
+        import warnings
+        import redback
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=RuntimeWarning)
+            flux_density = redback.transient_models.kilonova_models.one_component_kilonova_model(
+                np.array([0.5, 1.0, 2.0]), redshift=0.05, mej=0.01, vej=0.4, kappa=1.0,
+                temperature_floor=1000, output_format='flux_density', frequency=6e14)
+
+        self.assertTrue(np.all(np.isfinite(flux_density)))
+        self.assertTrue(np.all(flux_density >= 0.0))
     
     def test_basic_functionality(self):
         """Test that the function returns an array of the correct length."""

--- a/test/multimessenger_test.py
+++ b/test/multimessenger_test.py
@@ -1520,6 +1520,29 @@ class RealCodePathsTest(unittest.TestCase):
         np.testing.assert_array_equal(likelihood.x, np.array([1.0, 3.0]))
         np.testing.assert_array_equal(likelihood.y, np.array([10.0, 4.0]))
 
+    def test_build_likelihood_with_infinite_upper_limits_uses_detections_only(self):
+        """Infinite upper limits should not be silently treated as Gaussian data."""
+        detections = np.array([True, False, True])
+        transient = Transient(
+            time=np.array([1.0, 2.0, 3.0]),
+            flux=np.array([10.0, np.inf, 4.0]),
+            flux_err=np.ones(3),
+            data_mode='flux',
+            detections=detections,
+            name='infinite_upper_limit_optical'
+        )
+        mm = MultiMessengerTransient(optical_transient=transient)
+
+        def model(time, amplitude=1.0):
+            return amplitude * np.ones_like(time)
+
+        likelihood = mm._build_likelihood_for_messenger('optical', transient, model)
+
+        self.assertIsInstance(likelihood, GaussianLikelihood)
+        self.assertNotIsInstance(likelihood, GaussianLikelihoodWithUpperLimits)
+        np.testing.assert_array_equal(likelihood.x, np.array([1.0, 3.0]))
+        np.testing.assert_array_equal(likelihood.y, np.array([10.0, 4.0]))
+
     def test_upper_limit_likelihood_without_limits_preserves_time_errors(self):
         """Explicit upper-limit likelihood should not drop time errors if all points are detections."""
         transient = Transient(


### PR DESCRIPTION
## Summary

- document how measurement uncertainties are handled for detections and upper limits
- explain the roles of finite limit values, placeholder errors, and `upper_limit_sigma`
- fix the SNcosmo flux-density frequency-length validation
- accept Python and NumPy scalar frequencies consistently
- add regression coverage for non-finite upper-limit errors and SNcosmo scalar, per-epoch, and invalid frequency inputs

## Root cause

The SNcosmo wrapper intended to accept either one frequency or one frequency per epoch. Its validation joined the two conditions incorrectly, so a valid per-epoch frequency array was rejected precisely when its length equaled the time array. The corrected predicate rejects the input only when its length is neither one nor the number of epochs.

For upper limits, `GaussianLikelihoodWithUpperLimits` derives the effective uncertainty from the finite limit and `upper_limit_sigma`; measurement-error entries on upper-limit rows are not used. The documentation did not explain this distinction or how to sanitize table inputs.

Fixes #369.

## Validation

- `python -m pytest test/likelihood_test.py test/model_test.py -q`: 133 passed, 11 skipped
- focused regression suite: 13 passed
- real SALT2 evaluations with scalar and per-epoch frequencies return finite mJy arrays


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gaussian likelihood support for AB-magnitude measurements, including uncertainty propagation and flux-density model comparison.

* **Bug Fixes**
  * Improved flux-density calculations for scalar and per-observation frequencies.
  * Strengthened validation for invalid uncertainties, mismatched frequency data, and nonfinite upper limits.
  * Stabilized kilonova luminosity calculations for extreme valid parameters.

* **Documentation**
  * Clarified magnitude-to-flux conversion, uncertainty requirements, and upper-limit handling.

* **Tests**
  * Expanded coverage for likelihoods, frequency conversion, validation, upper limits, and kilonova stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->