### PR TITLE
Document and enforce generic afterglow naming

### DIFF
--- a/docs/getting_data.txt
+++ b/docs/getting_data.txt
@@ -46,6 +46,11 @@ For example, the kilonova data will be saved to :code:`kilonova/at2017gfo.csv`,
 afterglow will be saved to :code:`GRBData/afterglow/flux/GRB070809.csv` and
 TDE data will be saved to :code:`tde/at2019dsg.csv`.
 
+The :code:`GRBData` path is specific to afterglows downloaded from Swift and to the
+:code:`SGRB`/:code:`LGRB` classes. A directly constructed generic :code:`Afterglow` preserves the
+supplied event name and uses :code:`afterglow/`; see :ref:`afterglow-names-and-directories` for the
+complete naming convention.
+
 Please look at the API or the examples to see how we can get other data.
 
 Basic processing and metadata

--- a/docs/transients.txt
+++ b/docs/transients.txt
@@ -99,6 +99,26 @@ Note that in the supernova object, we set :code:`phase_model=True`.
 This sets the time attribute of the class to the modified julian date time of the observations.
 This is specifically for situations when users want to also sample the start time of the transient.
 
+.. _afterglow-names-and-directories:
+
+Afterglow names and directories
+-------------------------------
+
+:code:`Afterglow` is the generic class for GRB and non-GRB afterglows. It treats :code:`name` as an
+opaque event identifier and preserves its spelling. For example, :code:`Afterglow(name="AT2026abc",
+...)` has :code:`name == "AT2026abc"` and uses the local :code:`afterglow/` data directory.
+
+:code:`SGRB` and :code:`LGRB` are GRB-specific subclasses. They accept identifiers with or without
+the :code:`GRB` prefix and remove spaces, so :code:`"230307A"`, :code:`"GRB230307A"`, and
+:code:`"GRB 230307A"` are all stored as :code:`"GRB230307A"`. These subclasses retain the legacy
+:code:`GRBData/afterglow/<data_mode>/` directory layout.
+
+:code:`Afterglow.from_swift_grb`, :code:`SGRB.from_swift_grb`, and
+:code:`LGRB.from_swift_grb` are explicitly Swift-GRB constructors. They apply the same GRB
+normalization and use the legacy Swift directory layout even when called on :code:`Afterglow`.
+Construct :code:`Afterglow` directly for a non-GRB event. Redback does not move or rename existing
+files when an object is constructed.
+
 FXT objects are not connected to a broker or catalog data getter in :code:`redback`.
 No current :code:`redback.get_data` backend can fetch FXT data, so construct :code:`redback.transient.FXT`
 directly from local, private, simulated, or externally downloaded spectra.

--- a/redback/transient/afterglow.py
+++ b/redback/transient/afterglow.py
@@ -37,7 +37,8 @@ class Afterglow(Transient):
         the data mode you are using. For luminosity data provide times in the rest frame, if using a phase model
         provide time in MJD, else use the default time (observer frame).
 
-        :param name: Telephone number of GRB, e.g., 'GRB140903A' or '140903A' are valid inputs
+        :param name: Event identifier. Generic afterglows preserve this value exactly. The
+            :class:`SGRB` and :class:`LGRB` subclasses normalize GRB identifiers.
         :type name: str
         :param data_mode: Data mode. Must be one from `Afterglow.DATA_MODES`.
         :type data_mode: str, optional
@@ -135,6 +136,10 @@ class Afterglow(Transient):
 
         """
         afterglow = cls(name=cls._normalise_grb_name(name), data_mode=data_mode, **kwargs)
+        # Swift is a GRB catalogue even when this constructor is called on the
+        # generic Afterglow class.
+        afterglow._uses_grb_directory = True
+        afterglow._set_directory_structure()
         afterglow.snr = snr
 
         afterglow._set_data()
@@ -457,7 +462,7 @@ class Afterglow(Transient):
 
 
 class SGRB(Afterglow):
-    """ """
+    """Short-GRB afterglow with a canonical ``GRB<identifier>`` name."""
     _uses_grb_directory = True
 
     def __init__(self, name: str, *args, **kwargs):
@@ -465,7 +470,7 @@ class SGRB(Afterglow):
 
 
 class LGRB(Afterglow):
-    """ """
+    """Long-GRB afterglow with a canonical ``GRB<identifier>`` name."""
     _uses_grb_directory = True
 
     def __init__(self, name: str, *args, **kwargs):

--- a/test/transient_test.py
+++ b/test/transient_test.py
@@ -748,6 +748,17 @@ class TestAfterglow(unittest.TestCase):
             use_phase_model=self.use_phase_model)
         self.assertEqual("GRB070809", sgrb.name)
 
+    @patch.object(redback.transient.afterglow.Afterglow, 'load_and_truncate_data')
+    def test_generic_swift_constructor_uses_grb_identity_and_directory(self, load_data):
+        afterglow = redback.transient.afterglow.Afterglow.from_swift_grb(
+            name="GRB 070809", data_mode=self.data_mode,
+            time=self.time, time_err=self.time_err, flux=self.y, flux_err=self.y_err,
+            use_phase_model=self.use_phase_model)
+
+        self.assertEqual("GRB070809", afterglow.name)
+        self.assertIn("GRBData/afterglow", afterglow.directory_structure.directory_path)
+        load_data.assert_called_once()
+
     def test_truncate(self):
         expected_x = np.array([1.0, 2.0])
         expected_x_err = np.array([[0.1, 0.2], [0.1, 0.2]])


### PR DESCRIPTION
## Summary
- preserve supplied names for generic Afterglow objects
- retain GRB normalization and legacy directories for SGRB, LGRB, and Swift constructors
- document the naming and directory contract

## Validation
- 158 transient tests passed
- changed documentation sections introduce no new Sphinx warnings