### PR TITLE
Split optional feature dependencies

### DIFF
--- a/.github/workflows/optional-installs.yml
+++ b/.github/workflows/optional-installs.yml
@@ -1,0 +1,43 @@
+name: Optional extra install smoke tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  install-extra:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extra: [afterglow, data, speed, docs]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install Redback extra
+        run: python -m pip install ".[${{ matrix.extra }}]"
+      - name: Import Redback and selected dependency
+        env:
+          REDBACK_EXTRA: ${{ matrix.extra }}
+        run: |
+          cd /tmp
+          python - <<'PY'
+          import importlib
+          import os
+          import redback
+
+          modules = {
+              "afterglow": "afterglowpy",
+              "data": "astroquery",
+              "speed": "numba",
+              "docs": "sphinx",
+          }
+          importlib.import_module(modules[os.environ["REDBACK_EXTRA"]])
+          print(redback.__version__)
+          PY

--- a/.github/workflows/optional-installs.yml
+++ b/.github/workflows/optional-installs.yml
@@ -33,11 +33,12 @@ jobs:
           import redback
 
           modules = {
-              "afterglow": "afterglowpy",
-              "data": "astroquery",
-              "speed": "numba",
-              "docs": "sphinx",
+              "afterglow": ["afterglowpy"],
+              "data": ["astroquery", "otter", "swifttools"],
+              "speed": ["numba"],
+              "docs": ["sphinx"],
           }
-          importlib.import_module(modules[os.environ["REDBACK_EXTRA"]])
+          for module in modules[os.environ["REDBACK_EXTRA"]]:
+              importlib.import_module(module)
           print(redback.__version__)
           PY

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,7 +32,7 @@ jobs:
             test/examples_test.py test/model_library_test.py test/simulate_transient_test.py test/test_on_ref_results.py
             test/filters_test.py test/fireball_models_test.py test/gaussianprocess_models_test.py test/priors_test.py
             test/prompt_models_test.py test/wrappers_test.py test/constraints_test.py test/ejecta_relations_test.py
-            test/sed_test.py test/interaction_processes_test.py test/spectral_models_test.py test/extinction_test.py
+            test/sed_test.py test/optional_dependencies_test.py test/interaction_processes_test.py test/spectral_models_test.py test/extinction_test.py
             test/multimessenger_test.py test/model_prior_health_test.py"
           # Group 5: More Medium tests
           - test-group: 5

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -10,7 +10,7 @@ Installation
 
           $ pip install redback
 
-      Supported Python versions: 3.10+.
+      Supported Python versions: 3.11+.
 
 
 This will install all requirements for running :code:`redback` for general transient fitting, including bilby and our default sampler `dynesty
@@ -22,7 +22,7 @@ Therefore, for the near future, we recommend installing :code:`redback` from sou
 Install :code:`redback` from source
 -------------------------
 
-:code:`redback` is developed and tested with Python 3.10+. In the
+:code:`redback` is developed and tested with Python 3.11+. In the
 following, we assume you have a working python installation, `python pip
 <https://packaging.python.org/tutorials/installing-packages/#use-pip-for-installing>`_,
 and `git <https://git-scm.com/>`_.

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -50,7 +50,7 @@ Install only the optional functionality needed by an analysis:
 .. code-block:: console
 
    $ pip install "redback[afterglow]"  # afterglowpy-backed jet models
-   $ pip install "redback[data]"       # SVO and Swift catalogue access
+   $ pip install "redback[data]"       # SVO, Swift, and OTTER catalogue access
    $ pip install "redback[speed]"      # optional Numba acceleration
    $ pip install "redback[ml]"         # GP, heating-rate, and learned models
    $ pip install "redback[docs]"       # documentation build tools

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -10,7 +10,7 @@ Installation
 
           $ pip install redback
 
-      Supported python versions: 3.11+.
+      Supported Python versions: 3.10+.
 
 
 This will install all requirements for running :code:`redback` for general transient fitting, including bilby and our default sampler `dynesty
@@ -22,7 +22,7 @@ Therefore, for the near future, we recommend installing :code:`redback` from sou
 Install :code:`redback` from source
 -------------------------
 
-:code:`redback` is developed and tested with Python 3.11+. In the
+:code:`redback` is developed and tested with Python 3.10+. In the
 following, we assume you have a working python installation, `python pip
 <https://packaging.python.org/tutorials/installing-packages/#use-pip-for-installing>`_,
 and `git <https://git-scm.com/>`_.
@@ -45,11 +45,21 @@ To install with development mode, use:
    $ pip install -r requirements.txt
    $ pip install -e .
 
-For full functionality, please also install optional requirements.
+Install only the optional functionality needed by an analysis:
 
 .. code-block:: console
 
-   $ pip install -r optional_requirements.txt
+   $ pip install "redback[afterglow]"  # afterglowpy-backed jet models
+   $ pip install "redback[data]"       # SVO and Swift catalogue access
+   $ pip install "redback[speed]"      # optional Numba acceleration
+   $ pip install "redback[ml]"         # GP, heating-rate, and learned models
+   $ pip install "redback[docs]"       # documentation build tools
+   $ pip install "redback[all]"        # all optional functionality
+
+The base installation retains :code:`sncosmo`, which is used by core optical photometry, filters,
+and SED calculations. An optional extra only controls functionality that imports cleanly without
+that dependency. Missing optional packages raise an installation-specific :code:`ImportError` when
+the corresponding feature is called, rather than making :code:`import redback` fail.
 
 You are now ready to use redback. Please check out the `examples <https://github.com/nikhil-sarin/redback/tree/master/examples>`_
 
@@ -60,11 +70,11 @@ Installing phantomjs essentially requires that you first download the phantomjs 
 the `website <https://phantomjs.org/download.html>`_. Then create a softlink or export the path to the bin file;
 see discussion on `stackoverflow <https://stackoverflow.com/questions/36993962/installing-phantomjs-on-mac>`_.
 Now, If you want to use :code:`redback` functionality to download Swift data, you need to install the swifttools package.
-This is included in the optional requirements.
+This is included in the :code:`data` extra.
 
 .. code-block:: console
 
-    $ pip install swifttools
+    $ pip install "redback[data]"
 
 The swifttools package provides direct API access to Swift data from the UK Swift Science Data Centre, 
 eliminating the need for web scraping with Selenium or PhantomJS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "numba",
     "setuptools",
     "pandas",
     "scipy",
@@ -32,16 +31,31 @@ dependencies = [
     "extinction",
     "requests",
     "lxml",
-    "sphinx-rtd-theme",
-    "sphinx-tabs",
     "bilby",
     "regex",
     "sncosmo",
-    "afterglowpy",
 ]
 
 [project.optional-dependencies]
+afterglow = ["afterglowpy"]
+data = ["astroquery", "swifttools"]
+docs = ["sphinx", "sphinx-rtd-theme", "sphinx-tabs"]
+speed = ["numba"]
+ml = [
+    "george",
+    "scikit-learn",
+    "tensorflow",
+    "keras",
+    "kilonova-heating-rate",
+    "redback-surrogates",
+    "kilonovanet",
+]
 all = [
+    "afterglowpy",
+    "numba",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-tabs",
     "nestle",
     "sherpa",
     "george",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 afterglow = ["afterglowpy"]
-data = ["astroquery", "swifttools"]
+data = ["astroquery", "astro-otter", "swifttools"]
 docs = ["sphinx", "sphinx-rtd-theme", "sphinx-tabs"]
 speed = ["numba"]
 ml = [
@@ -68,6 +68,7 @@ all = [
     "keras",
     "kilonovanet",
     "astroquery",
+    "astro-otter",
     "pyphot==1.6.0",
     "swifttools",
 ]

--- a/redback/filters.py
+++ b/redback/filters.py
@@ -1,10 +1,18 @@
 from astropy.io import ascii
 from astropy import units as u
-from astroquery.svo_fps import SvoFps
 import numpy as np
 from redback.utils import calc_effective_width_hz_from_angstrom
 import redback
 import sncosmo
+
+
+def _get_svo_fps():
+    try:
+        from astroquery.svo_fps import SvoFps
+    except ImportError as exc:
+        raise ImportError(
+            "SVO filter downloads require astroquery; install redback[data].") from exc
+    return SvoFps
 
 def add_to_database(label, wavelength, zeroflux, database, plot_label, effective_width):
 
@@ -90,7 +98,7 @@ def add_filter_svo(filter, label, plot_label=None, overwrite=False):
 
     # Non-standard filters always needs to be re-added to SN Cosmo even if an entry exists in filter.csv
 
-    filter_transmission = SvoFps.get_transmission_data(filter['filterID'])
+    filter_transmission = _get_svo_fps().get_transmission_data(filter['filterID'])
     add_to_sncosmo(label, filter_transmission)
 
     # Prettify output
@@ -197,7 +205,7 @@ def add_common_filters(overwrite=False):
 
     print('MPG/GROND optical and NIR filters...')
 
-    filter_list  = SvoFps.get_filter_list(facility='La Silla', instrument='GROND')
+    filter_list  = _get_svo_fps().get_filter_list(facility='La Silla', instrument='GROND')
     filter_label = ['grond::' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
     plot_label   = ['GROND/' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
 
@@ -210,7 +218,7 @@ def add_common_filters(overwrite=False):
 
     print('NTT/EFOSC2 Gunn filters...')
 
-    filter_list  = SvoFps.get_filter_list(facility='La Silla', instrument='EFOSC')
+    filter_list  = _get_svo_fps().get_filter_list(facility='La Silla', instrument='EFOSC')
     mask         = [True if ('Gunn' in filter_list['Description'][ii]) else False for ii in range(len(filter_list))]
     filter_list  = filter_list[mask]
     filter_label = ['efosc2::' + x for x in filter_list['Band']]
@@ -224,14 +232,14 @@ def add_common_filters(overwrite=False):
 
     print('EUCLID optical and IR filters...')
 
-    filter_list  = SvoFps.get_filter_list(facility='Euclid', instrument='VIS')
+    filter_list  = _get_svo_fps().get_filter_list(facility='Euclid', instrument='VIS')
     filter_label = ['euclid::' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
     plot_label   = ['EUCLID/' + x.split('/')[1].split('.')[1].upper() for x in filter_list['filterID']]
 
     [add_filter_svo(filter_list[ii], filter_label[ii], plot_label[ii], overwrite=overwrite) for ii in range(len(filter_list))]
 
 
-    filter_list  = SvoFps.get_filter_list(facility='Euclid', instrument='NISP')
+    filter_list  = _get_svo_fps().get_filter_list(facility='Euclid', instrument='NISP')
     mask         = [True if 'NISP.' in filter_list['filterID'][ii] else False for ii in range(len(filter_list))]
     filter_list  = filter_list[mask]
     filter_label = ['euclid::' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
@@ -245,7 +253,7 @@ def add_common_filters(overwrite=False):
 
     print('Spitzer IRAC filters...')
 
-    filter_list  = SvoFps.get_filter_list(facility='Spitzer', instrument='IRAC')
+    filter_list  = _get_svo_fps().get_filter_list(facility='Spitzer', instrument='IRAC')
     filter_label = ['irac::' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
     plot_label   = ['IRAC/' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
 
@@ -257,7 +265,7 @@ def add_common_filters(overwrite=False):
 
     print('WISE filters...')
 
-    filter_list  = SvoFps.get_filter_list(facility='WISE')
+    filter_list  = _get_svo_fps().get_filter_list(facility='WISE')
     filter_label = ['wise::' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
     plot_label   = ['WISE/' + x.split('/')[1].split('.')[1] for x in filter_list['filterID']]
 

--- a/redback/get_data/__init__.py
+++ b/redback/get_data/__init__.py
@@ -18,7 +18,7 @@ from redback.utils import logger
 try:
     from redback.get_data import otter
     from redback.get_data.otter import OtterDataGetter
-    OTTER_AVAILABLE = True
+    OTTER_AVAILABLE = otter.OTTER_INSTALLED
 except ImportError:
     OTTER_AVAILABLE = False
     logger.debug("astro-otter is not installed; OTTER data access is unavailable.")
@@ -296,7 +296,8 @@ def get_kilonova_data_from_otter(transient: str, obs_type: str = 'uvoir', **kwar
     :rtype: pandas.DataFrame
     """
     if not OTTER_AVAILABLE:
-        raise ImportError("astro-otter is not installed. Please install it with: pip install astro-otter")
+        raise ImportError(
+            "OTTER data access requires astro-otter; install redback[data].")
     getter = OtterDataGetter(transient=transient, transient_type='kilonova', obs_type=obs_type)
     return getter.get_data()
 
@@ -316,7 +317,8 @@ def get_supernova_data_from_otter(transient: str, obs_type: str = 'uvoir', **kwa
     :rtype: pandas.DataFrame
     """
     if not OTTER_AVAILABLE:
-        raise ImportError("astro-otter is not installed. Please install it with: pip install astro-otter")
+        raise ImportError(
+            "OTTER data access requires astro-otter; install redback[data].")
     getter = OtterDataGetter(transient=transient, transient_type='supernova', obs_type=obs_type)
     return getter.get_data()
 
@@ -336,7 +338,8 @@ def get_tidal_disruption_event_data_from_otter(transient: str, obs_type: str = '
     :rtype: pandas.DataFrame
     """
     if not OTTER_AVAILABLE:
-        raise ImportError("astro-otter is not installed. Please install it with: pip install astro-otter")
+        raise ImportError(
+            "OTTER data access requires astro-otter; install redback[data].")
     getter = OtterDataGetter(transient=transient, transient_type='tidal_disruption_event', obs_type=obs_type)
     return getter.get_data()
 

--- a/redback/get_data/__init__.py
+++ b/redback/get_data/__init__.py
@@ -21,7 +21,7 @@ try:
     OTTER_AVAILABLE = True
 except ImportError:
     OTTER_AVAILABLE = False
-    logger.warning("astro-otter not installed. Otter data getter functionality will not be available.")
+    logger.debug("astro-otter is not installed; OTTER data access is unavailable.")
 
 SWIFT_PROMPT_BIN_SIZES = ['1s', '2ms', '8ms', '16ms', '64ms', '256ms']
 

--- a/redback/get_data/otter.py
+++ b/redback/get_data/otter.py
@@ -75,7 +75,7 @@ class OtterDataGetter(DataGetter):
             error_msg = "OTTER is not available. "
             if 'OTTER_IMPORT_ERROR' in globals():
                 error_msg += f"Import error: {OTTER_IMPORT_ERROR}. "
-            error_msg += "Try: pip install astro-otter"
+            error_msg += "Install it with redback[data]."
             raise ImportError(error_msg)
         
         # Handle list of obs_types

--- a/redback/get_data/swift.py
+++ b/redback/get_data/swift.py
@@ -21,7 +21,7 @@ try:
     SWIFTTOOLS_AVAILABLE = True
 except ImportError:
     SWIFTTOOLS_AVAILABLE = False
-    logger.warning("swifttools not available. You will not be able to download Swift afterglow data via API.")
+    logger.debug("swifttools is not installed; Swift API downloads are unavailable.")
 
 dirname = os.path.dirname(__file__)
 

--- a/redback/get_data/swift.py
+++ b/redback/get_data/swift.py
@@ -231,8 +231,8 @@ class SwiftDataGetter(GRBDataGetter):
 
         if not SWIFTTOOLS_AVAILABLE:
             raise ImportError(
-                "swifttools is required for Swift afterglow data retrieval. "
-                "Please install it with: pip install swifttools"
+                "swifttools is required for Swift afterglow data retrieval; "
+                "install redback[data]."
             )
         
         # Check if raw data already exists and can be loaded (unless force_download is True)
@@ -300,8 +300,8 @@ class SwiftDataGetter(GRBDataGetter):
         :rtype: pandas.DataFrame
         """
         if not SWIFTTOOLS_AVAILABLE:
-            raise ImportError("swifttools is required for API-based data retrieval. "
-                            "Please install it with: pip install swifttools")
+            raise ImportError(
+                "swifttools is required for Swift API data retrieval; install redback[data].")
 
         try:
             logger.info(f'Downloading XRT data for {self.grb} using swifttools API')
@@ -390,8 +390,8 @@ class SwiftDataGetter(GRBDataGetter):
         :rtype: dict
         """
         if not SWIFTTOOLS_AVAILABLE:
-            raise ImportError("swifttools is required for API-based data retrieval. "
-                            "Please install it with: pip install swifttools")
+            raise ImportError(
+                "swifttools is required for Swift API data retrieval; install redback[data].")
 
         try:
             logger.info(f'Downloading Burst Analyser data for {self.grb} using swifttools API')

--- a/redback/transient_models/afterglow_models/base_models.py
+++ b/redback/transient_models/afterglow_models/base_models.py
@@ -6,20 +6,33 @@ from redback.sed import get_correct_output_format_from_spectra
 import astropy.units as uu
 import numpy as np
 from collections import namedtuple
+from importlib import import_module
 from scipy.special import erf
 from redback.wrappers import cond_jit
 
-try:
-    import afterglowpy as afterglow
+afterglow = None
+jettype_dict = None
+spectype_dict = None
 
-    jettype_dict = {'tophat': afterglow.jet.TopHat, 'gaussian': afterglow.jet.Gaussian,
-                    'powerlaw_w_core': afterglow.jet.PowerLawCore, 'gaussian_w_core': afterglow.jet.GaussianCore,
-                    'cocoon': afterglow.Spherical, 'smooth_power_law': afterglow.jet.PowerLaw,
-                    'cone': afterglow.jet.Cone}
+
+def _load_afterglowpy():
+    """Import afterglowpy only when an afterglowpy-backed model is evaluated."""
+    global afterglow, jettype_dict, spectype_dict
+    if afterglow is not None:
+        return afterglow
+    try:
+        afterglow = import_module("afterglowpy")
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            "This model requires afterglowpy; install redback[afterglow].") from exc
+    jettype_dict = {
+        'tophat': afterglow.jet.TopHat, 'gaussian': afterglow.jet.Gaussian,
+        'powerlaw_w_core': afterglow.jet.PowerLawCore,
+        'gaussian_w_core': afterglow.jet.GaussianCore,
+        'cocoon': afterglow.Spherical, 'smooth_power_law': afterglow.jet.PowerLaw,
+        'cone': afterglow.jet.Cone}
     spectype_dict = {'no_inverse_compton': 0, 'inverse_compton': 1}
-except ModuleNotFoundError as e:
-    logger.warning(e)
-    afterglow = None
+    return afterglow
 
 jet_spreading_models = ['tophat', 'cocoon', 'gaussian',
                           'kn_afterglow', 'cone_afterglow',
@@ -1758,6 +1771,7 @@ def cocoon(time, redshift, umax, umin, loge0, k, mej, logn0, p, logepse, logepsb
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['cocoon']
     frequency = kwargs['frequency']
     e0 = 10 ** loge0
@@ -1850,6 +1864,7 @@ def cone_afterglow(time, redshift, thv, loge0, thw, thc, logn0, p, logepse, loge
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['cone']
     frequency = kwargs['frequency']
     thw = thw * thc
@@ -1907,6 +1922,7 @@ def gaussiancore(time, redshift, thv, loge0, thc, thw, logn0, p, logepse, logeps
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['gaussian_w_core']
     frequency = kwargs['frequency']
 
@@ -1965,6 +1981,7 @@ def gaussian(time, redshift, thv, loge0, thw, thc, logn0, p, logepse, logepsb, k
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['gaussian']
     frequency = kwargs['frequency']
     thw = thw * thc
@@ -2023,6 +2040,7 @@ def smoothpowerlaw(time, redshift, thv, loge0, thw, thc, beta, logn0, p, logepse
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['smooth_power_law']
     frequency = kwargs['frequency']
     thw = thw * thc
@@ -2081,6 +2099,7 @@ def powerlawcore(time, redshift, thv, loge0, thw, thc, beta, logn0, p, logepse, 
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['powerlaw_w_core']
     frequency = kwargs['frequency']
     thw = thw * thc
@@ -2138,6 +2157,7 @@ def tophat(time, redshift, thv, loge0, thc, logn0, p, logepse, logepsb, ksin, g0
     l0 = kwargs.get('L0', 0)
     q = kwargs.get('q', 0)
     ts = kwargs.get('ts', 0)
+    afterglow = _load_afterglowpy()
     jettype = jettype_dict['tophat']
     frequency = kwargs['frequency']
     e0 = 10 ** loge0

--- a/redback/wrappers.py
+++ b/redback/wrappers.py
@@ -23,7 +23,7 @@ def cond_jit(func=None, **kwargs):
 
         decorator = jit(**kwargs)
     except ImportError:
-        logger.warning("Numba is not installed. Using the non-compiled function.")
+        logger.debug("Numba is not installed; using the non-compiled function.")
 
         # If numba is not available, fall back to a no-op decorator.
         def no_op_decorator(func):

--- a/test/get_data_test.py
+++ b/test/get_data_test.py
@@ -2256,6 +2256,7 @@ class TestOtterWrapperFunctions(unittest.TestCase):
     def tearDown(self) -> None:
         _delete_downloaded_files()
 
+    @mock.patch("redback.get_data.OTTER_AVAILABLE", True)
     @mock.patch("redback.get_data.OtterDataGetter")
     def test_get_kilonova_data_from_otter(self, OtterDataGetter):
         """Test kilonova wrapper function"""
@@ -2274,6 +2275,7 @@ class TestOtterWrapperFunctions(unittest.TestCase):
         mock_getter.get_data.assert_called_once()
         self.assertIsInstance(result, pd.DataFrame)
 
+    @mock.patch("redback.get_data.OTTER_AVAILABLE", True)
     @mock.patch("redback.get_data.OtterDataGetter")
     def test_get_supernova_data_from_otter(self, OtterDataGetter):
         """Test supernova wrapper function"""
@@ -2292,6 +2294,7 @@ class TestOtterWrapperFunctions(unittest.TestCase):
         mock_getter.get_data.assert_called_once()
         self.assertIsInstance(result, pd.DataFrame)
 
+    @mock.patch("redback.get_data.OTTER_AVAILABLE", True)
     @mock.patch("redback.get_data.OtterDataGetter")
     def test_get_tde_data_from_otter(self, OtterDataGetter):
         """Test TDE wrapper function"""

--- a/test/optional_dependencies_test.py
+++ b/test/optional_dependencies_test.py
@@ -3,7 +3,9 @@ from unittest import mock
 
 import pytest
 
+import redback.get_data as get_data
 import redback.filters as filters
+from redback.get_data import otter
 from redback.transient_models.afterglow_models import base_models
 
 
@@ -25,3 +27,13 @@ def test_svo_filters_report_the_data_extra_when_astroquery_is_missing():
             sys.modules, {"astroquery": None, "astroquery.svo_fps": None}):
         with pytest.raises(ImportError, match=r"redback\[data\]"):
             filters._get_svo_fps()
+
+
+def test_otter_availability_reflects_backend_import():
+    assert get_data.OTTER_AVAILABLE is otter.OTTER_INSTALLED
+
+
+def test_otter_wrapper_reports_the_data_extra_when_backend_is_missing():
+    with mock.patch.object(get_data, "OTTER_AVAILABLE", False):
+        with pytest.raises(ImportError, match=r"redback\[data\]"):
+            get_data.get_kilonova_data_from_otter("AT2017gfo")

--- a/test/optional_dependencies_test.py
+++ b/test/optional_dependencies_test.py
@@ -1,0 +1,27 @@
+import sys
+from unittest import mock
+
+import pytest
+
+import redback.filters as filters
+from redback.transient_models.afterglow_models import base_models
+
+
+def test_afterglowpy_is_loaded_only_when_requested():
+    original = (base_models.afterglow, base_models.jettype_dict, base_models.spectype_dict)
+    try:
+        base_models.afterglow = None
+        base_models.jettype_dict = None
+        base_models.spectype_dict = None
+        with mock.patch.object(base_models, "import_module", side_effect=ModuleNotFoundError):
+            with pytest.raises(ImportError, match=r"redback\[afterglow\]"):
+                base_models._load_afterglowpy()
+    finally:
+        base_models.afterglow, base_models.jettype_dict, base_models.spectype_dict = original
+
+
+def test_svo_filters_report_the_data_extra_when_astroquery_is_missing():
+    with mock.patch.dict(
+            sys.modules, {"astroquery": None, "astroquery.svo_fps": None}):
+        with pytest.raises(ImportError, match=r"redback\[data\]"):
+            filters._get_svo_fps()


### PR DESCRIPTION
## Summary
- add afterglow, data, speed, ml, docs, and all extras
- lazy-load afterglowpy and SVO dependencies with actionable errors
- include Swift, SVO, and OTTER backends in the data extra
- make OTTER availability reflect the actual backend import
- add optional-extra installation CI

## Dependency
This PR is intentionally based on feature/modern-packaging. Retarget it to master after that PR merges.

## Validation
- 2267 tests passed and 31 skipped with live-network and known order-dependent tests deselected
- focused optional and data-backend tests passed
- isolated distributions built successfully and passed Twine checks