### PR TITLE
Release v1.20.0

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     tags:
       - 'v*'  # Trigger on version tags like v1.12.1, v2.0.0, etc.
-  workflow_dispatch:  # Allow manual trigger
 
 permissions:
   contents: read
@@ -19,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -29,6 +30,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build setuptools wheel twine
+
+    - name: Verify tag matches package version
+      run: |
+        package_version=$(python -c "import runpy; print(runpy.run_path('redback/_version.py')['__version__'])")
+        if [ "${GITHUB_REF_NAME}" != "v${package_version}" ]; then
+          echo "Tag ${GITHUB_REF_NAME} does not match package version ${package_version}" >&2
+          exit 1
+        fi
 
     - name: Build distribution packages
       run: python -m build
@@ -90,7 +99,8 @@ jobs:
       run: |
         gh release create '${{ github.ref_name }}' \
           --repo '${{ github.repository }}' \
-          --notes "Release ${{ github.ref_name }}"
+          --title '${{ github.ref_name }}' \
+          --generate-notes
 
     - name: Upload distribution packages to GitHub Release
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # All notable changes will be documented in this file
 
+## [1.20.0] 2026-09-10
+Version 1.20.0 release of redback
+
+### New features
+- Add bounded MAP and maximum-likelihood point estimation through `redback.fit_model(..., fit_method="map")` and `fit_method="mle"`, returning standard `RedbackResult` objects
+- Add support for Laplace approximate-posterior inference through Bilby's `bilby-laplace` sampler plugin
+- Add `GaussianLikelihoodOnMagnitudeFlux` for fitting magnitude-mode models with Gaussian residuals in flux-density space
+- Add the structured `estimate_sed()` API with blackbody, cutoff-blackbody, and direct-integration methods, covariance-aware uncertainties, extinction-aware forward modelling, diagnostics, and compatibility wrappers
+- Make the base `Afterglow` class preserve generic transient names while retaining GRB normalization in `SGRB` and `LGRB`
+
+### Bug fixes
+- Fix time-zero masking for list-valued per-epoch model arguments
+- Fix SNcosmo flux-density evaluation at scalar frequencies and the boundary equality condition
+- Validate upper-limit values and significance levels before evaluating upper-limit likelihoods
+- Preserve causal kilonova diffusion output up to the first invalid heating epoch
+- Fix sampled peak-time handling in phase models
+- Stabilize OTTER dataframe conversion
+- Fix Fink directory routing and pandas 3 compatibility in Open Data system handling
+
+### Packaging and stability
+- Migrate package metadata to `pyproject.toml` with an import-free version source
+- Require Python 3.11 or newer
+- Split optional dependencies into `afterglow`, `data`, `docs`, `speed`, and `ml` extras
+- Add clean wheel, source-distribution, and optional-extra installation checks
+- Add deterministic conversion regression tests for Fink, Lasair, and Open Data
+- Raise combined test coverage above 90% and enforce the threshold without integer rounding
+- Move live Fink service checks to a dedicated scheduled workflow
+- Deprecate `Likelihood.find_maximum_likelihood_parameters` in favor of `fit_model`
+
+**Full Changelog**: https://github.com/nikhil-sarin/redback/compare/v1.18.0...v1.20.0
+
 ## [1.18.0] 2026-07-27
 Version 1.18.0 release of redback
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@
 #
 import os
 import sys
+from pathlib import Path
+from runpy import run_path
 sys.path.insert(0, os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
@@ -21,7 +23,8 @@ copyright = '2022, Nikhil Sarin, Moritz Hübner'
 author = 'Nikhil Sarin, Moritz Hübner'
 
 # The full version, including alpha/beta/rc tags
-release = 'alpha'
+release = run_path(Path(__file__).parents[1] / 'redback' / '_version.py')['__version__']
+version = '.'.join(release.split('.')[:2])
 autosummary_generate = True
 autodoc_mock_imports = ["bilby"]
 

--- a/docs/contributing.txt
+++ b/docs/contributing.txt
@@ -2,7 +2,8 @@
 Contributing
 ============
 
-Redback is currently at version 1.5.1. The version that accompanied the paper was v1.0.
+The version of Redback that accompanied the paper was v1.0. Current releases are listed on
+`GitHub <https://github.com/nikhil-sarin/redback/releases>`_.
 
 If you are interested in contributing please join the
 :code:`redback` `slack <https://join.slack.com/t/redback-group/shared_invite/zt-2503mmkaq-EMEAgz7i3mY0pg1o~VUdqw>`_.

--- a/redback/_version.py
+++ b/redback/_version.py
@@ -1,3 +1,3 @@
 """Redback version information without importing the package."""
 
-__version__ = "1.18.0"
+__version__ = "1.20.0"


### PR DESCRIPTION
## Summary
- bump the package version to 1.20.0
- document changes merged in PRs #372 through #379
- derive the documentation version from the package version source
- remove stale version text from the contribution guide
- require release tags to match the package version before publishing
- generate GitHub release notes and prevent checkout credential persistence

v1.20.0 intentionally follows v1.18.0: this release contains multiple new public APIs, a Python support-floor change, and packaging changes that justify the minor-version jump.

## Validation
- version source resolves to 1.20.0
- Sphinx configuration resolves to version 1.20 / release 1.20.0
- local isolated wheel and sdist build completed successfully as a preflight; GitHub Actions remains authoritative for distribution validation
- PR CI will run the full test, documentation, wheel/sdist, and optional-install workflows

## Release Process
After this PR merges, create and push the annotated tag `v1.20.0`. The tag-triggered workflow will verify the tag/version match, build and check distributions, publish to PyPI, and create the GitHub release.